### PR TITLE
Unify indentation format of the HTML code

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,186 +1,175 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
+  <head>
     <title>Arabic Layout Requirements</title>
     <meta charset="utf-8"/>
     <script src="https://www.w3.org/Tools/respec/respec-w3c-common"
-            async class="remove"></script>
+      async class="remove"></script>
     <script class="remove">
       var respecConfig = {
-          // specification status (e.g. WD, LCWD, WG-NOTE, etc.). If in doubt use ED.
-          specStatus:           "ED",
-          //publishDate:  "2015-07-21",
-          //previousPublishDate:  "2014-12-16",
-          //previousMaturity:  "FPWD",
+        // specification status (e.g. WD, LCWD, WG-NOTE, etc.). If in doubt use ED.
+        specStatus:           "ED",
+        //publishDate:          "2015-07-21",
+        //previousPublishDate:  "2014-12-16",
+        //previousMaturity:     "FPWD",
 
+        noRecTrack:     true,
+        shortName:      "alreq",
+        copyrightStart: "2015",
+        edDraftURI:     "http://w3c.github.io/alreq/",
 
-          noRecTrack:           true,
-          shortName:            "alreq",
-          copyrightStart: 		"2015",
-          edDraftURI:   		"http://w3c.github.io/alreq/",
+        // if this is a LCWD, uncomment and set the end of its review period
+        // lcEnd: "2009-08-05",
 
-          // if this is a LCWD, uncomment and set the end of its review period
-          // lcEnd: "2009-08-05",
+        // editors, add as many as you like
+        // only "name" is required
+        editors:  [
+          { name: "Shervin Afshar", mailto: "safshar@netflix.com", company: "Netflix" },
+          { name: "Behnam Esfahbod", mailto: "zwnj@fb.com", company: "Facebook" },
+          { name: "Najib Tounsi", mailto: "ntounsi@emi.ac.ma", company: "W3C" },
+          { name: "Mostafa Hajizadeh", mailto: "mostafa@daftar.cc" },
+        ],
 
-          // editors, add as many as you like
-          // only "name" is required
-          editors:  [
-              { name: "Shervin Afshar", mailto: "safshar@netflix.com", company: "Netflix" },
-              { name: "Behnam Esfahbod", mailto: "zwnj@fb.com", company: "Facebook" },
-              { name: "Najib Tounsi", mailto: "ntounsi@emi.ac.ma", company: "W3C" },
-              { name: "Mostafa Hajizadeh", mailto: "mostafa@daftar.cc" },
-          ],
+        wg:           "Internationalization Working Group",
+        wgURI:        "http://www.w3.org/International/core/",
+        wgPublicList: "public-i18n-arabic",
+        bugTracker: { new: "https://github.com/w3c/alreq/issues", open: "https://github.com/w3c/alreq/issues" } ,
+        otherLinks: [
+          {
+            key: "Github",
+            data: [
+              {
+                value: "repository",
+                href: "https://github.com/w3c/alreq"
+              }
+            ]
+          }
+        ],
 
-
-          wg:           "Internationalization Working Group",
-          wgURI:         "http://www.w3.org/International/core/",
-          wgPublicList: "public-i18n-arabic",
-		  bugTracker: { new: "https://github.com/w3c/alreq/issues", open: "https://github.com/w3c/alreq/issues" } ,
-		otherLinks: [
-			{
-			key: "Github",
-			data: [
-				{
-			  	value: "repository",
-			  	href: "https://github.com/w3c/alreq"
-		 		}
-				]
-			}
-			],
-		  
-          
-          // URI of the patent status for this WG, for Rec-track documents
-          // !!!! IMPORTANT !!!!
-          // This is important for Rec-track documents, do not copy a patent URI from a random
-          // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
-          // Team Contact.
-          wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/32113/status",
-          // !!!! IMPORTANT !!!! MAKE THE ABOVE BLINK IN YOUR HEAD
+        // URI of the patent status for this WG, for Rec-track documents
+        // !!!! IMPORTANT !!!!
+        // This is important for Rec-track documents, do not copy a patent URI from a random
+        // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
+        // Team Contact.
+        wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/32113/status",
+        // !!!! IMPORTANT !!!! MAKE THE ABOVE BLINK IN YOUR HEAD
       };
     </script>
-	<link rel="stylesheet" href="local.css" type="text/css" />
-    </head>
-    <body id="respecDocument" role="document" class="h-entry">
-<div id="abstract">
-  <p>This document describes requirements for the layout and presentation of text in languages that use the Arabic script when they are used by Web standards and technologies, such as HTML, CSS, Mobile Web, Digital Publications, and Unicode.</p>
-  </div>
-<div id="sotd">
+    <link rel="stylesheet" href="local.css" type="text/css" />
+  </head>
+
+  <body id="respecDocument" role="document" class="h-entry">
+    <div id="abstract">
+      <p>This document describes requirements for the layout and presentation of text in languages that use the Arabic script when they are used by Web standards and technologies, such as HTML, CSS, Mobile Web, Digital Publications, and Unicode.</p>
+    </div>
+    <div id="sotd">
       <p>This document describes the basic requirements for Arabic script layout and text support on the Web and in eBooks. These requirements provide information for Web technologies such as CSS, HTML and digital publications about how to support users of Arabic scripts.  Currently the document focuses on Standard Arabic and Persian. </p>
       <p>The editor's draft of this document is being developed by the <a href="http://www.w3.org/International/groups/arabic-layout/">Arabic Layout Task Force</a>, part of the W3C <a href="http://www.w3.org/International/ig/">Internationalization Interest Group</a>. It is published by the <a href="http://www.w3.org/International/core/">Internationalization Working Group</a>. The end target for this document is a Working Group Note.</p>
-    <div class="note">
-    <p data-lang="en" style="font-weight: bold; font-size: 120%">Sending comments on this document</p>
-  	<p data-lang="en">If you wish to make comments regarding this document, please raise them as <a href="https://github.com/w3c/alreq/issues" style="font-size: 120%;">github issues</a> <!--against the <a href="http://www.w3.org/TR/2015/WD-ilreq-20150721/" style="font-size: 120%">latest dated version in /TR</a>-->. Only send comments by email if you are unable to raise issues on github (see links below).   All comments are welcome.</p>
-  	<p data-lang="en">To make it easier to track comments, please raise separate issues or emails for each comment, and point to the section you are commenting on&nbsp; using  a URL for the dated version of the document.</p>
+      <div class="note">
+        <p data-lang="en" style="font-weight: bold; font-size: 120%">Sending comments on this document</p>
+        <p data-lang="en">If you wish to make comments regarding this document, please raise them as <a href="https://github.com/w3c/alreq/issues" style="font-size: 120%;">github issues</a> <!--against the <a href="http://www.w3.org/TR/2015/WD-ilreq-20150721/" style="font-size: 120%">latest dated version in /TR</a>-->. Only send comments by email if you are unable to raise issues on github (see links below).   All comments are welcome.</p>
+        <p data-lang="en">To make it easier to track comments, please raise separate issues or emails for each comment, and point to the section you are commenting on&nbsp; using  a URL for the dated version of the document.</p>
+      </div>
     </div>
-    </div>
-    
-    
-<section id="h_introduction">
+
+    <section id="h_introduction">
       <h2>Introduction</h2>
-      
-  <section id="h_about_this_document">
-    <h2>About this document</h2>
-      <p>Some text goes here.</p>
-  </section>
-</section>
-    
-    
-<section id="h_characters">
+
+      <section id="h_about_this_document">
+        <h2>About this document</h2>
+        <p>Some text goes here.</p>
+      </section>
+    </section>
+
+    <section id="h_characters">
       <h2>Characters</h2>
-    <p>Topic Keywords:</p>
+      <p>Topic Keywords:</p>
       <ul>
-	<li><strong>Characters in Use:</strong> Listing the characters--alphabet, diacritics, numerals, and punctuations--which are used with Arabic script. Distinguishing which character is used with which language. Provide sources for the classification (e.g. CLDR exemplar data). Address the issue of usage of Arabic numerals vs. Arabic-Indic vs. Eastern Arabic-Indic numerals with text in Arabic and Persian langauge and provide resources and guidelines on how to choose the right set of numerals based on the language.
-	<li><strong>Arrangement and Joining Behaviour:</strong> Describe the joining/non-joining behavour, use of diacritics and combining marks, and ligatures briefly and refer to Unicode Standard for in-detail description. Elaborate of zero-width joining and non-joining behaviour.</li>
-	<li><strong>Spacing:</strong> Use of space as word boundary and exceptions ("و" conjunction in Arabic orthography, "ل" before a non-Arabic script noun). Misuse of space in place of ZWNJ in some Arabic script languages.</li>
-	<li><strong>Font and Typographical considerations:</strong> Common typographical styles and their visual identity. Font size considerations for mixed-script text.</li>
+        <li><strong>Characters in Use:</strong> Listing the characters--alphabet, diacritics, numerals, and punctuations--which are used with Arabic script. Distinguishing which character is used with which language. Provide sources for the classification (e.g. CLDR exemplar data). Address the issue of usage of Arabic numerals vs. Arabic-Indic vs. Eastern Arabic-Indic numerals with text in Arabic and Persian langauge and provide resources and guidelines on how to choose the right set of numerals based on the language.
+        <li><strong>Arrangement and Joining Behaviour:</strong> Describe the joining/non-joining behavour, use of diacritics and combining marks, and ligatures briefly and refer to Unicode Standard for in-detail description. Elaborate of zero-width joining and non-joining behaviour.</li>
+        <li><strong>Spacing:</strong> Use of space as word boundary and exceptions ("و" conjunction in Arabic orthography, "ل" before a non-Arabic script noun). Misuse of space in place of ZWNJ in some Arabic script languages.</li>
+        <li><strong>Font and Typographical considerations:</strong> Common typographical styles and their visual identity. Font size considerations for mixed-script text.</li>
       </ul>
-</section>
-    
-    
-<section id="h_lines_and_paragraphs">
+    </section>
+
+    <section id="h_lines_and_paragraphs">
       <h2>Lines and Paragraphs</h2>
-    <p>Topic Keywords:</p>
+      <p>Topic Keywords:</p>
       <ul>
-	<li><strong>Line composition rules:</strong> Characters which can not appear in start and end of the line. Mid-word and mid-sentence line breaking behaviour.</li>
-	<li><strong>Punctuations:</strong> Use and positioning of punctuation marks in the sentence. Use of paired punctuation marks.</li>
-	<li><strong>Mixed script text:</strong></li>
-	<li><strong>Directionality and bidi:</strong> Breif description of bidi. Special considerations for mixed script text. Reference to further reading.</li>
-	<li><strong>Paragraph adjustment and alignment:</strong> Paragraph spacing and indentation rules.</li>
-	<li><strong>Tab setting:</strong></li>
-	<li><strong>Justification and Elongation/Tatweel/Kashida:</strong> Common <a href="#def_justify" class="termref">justification</a> methods.</li>
-	<li><strong>Hyphenation:</strong> Uses of hyphenation.</li>
-	<li><strong>Word/Sentence boundaries:</strong></li>
-	<li><strong>Special cases:</strong> Poetry, bullet lists, math, vertical text, drop-letters, etc.</li>
+        <li><strong>Line composition rules:</strong> Characters which can not appear in start and end of the line. Mid-word and mid-sentence line breaking behaviour.</li>
+        <li><strong>Punctuations:</strong> Use and positioning of punctuation marks in the sentence. Use of paired punctuation marks.</li>
+        <li><strong>Mixed script text:</strong></li>
+        <li><strong>Directionality and bidi:</strong> Breif description of bidi. Special considerations for mixed script text. Reference to further reading.</li>
+        <li><strong>Paragraph adjustment and alignment:</strong> Paragraph spacing and indentation rules.</li>
+        <li><strong>Tab setting:</strong></li>
+        <li><strong>Justification and Elongation/Tatweel/Kashida:</strong> Common <a href="#def_justify" class="termref">justification</a> methods.</li>
+        <li><strong>Hyphenation:</strong> Uses of hyphenation.</li>
+        <li><strong>Word/Sentence boundaries:</strong></li>
+        <li><strong>Special cases:</strong> Poetry, bullet lists, math, vertical text, drop-letters, etc.</li>
       </ul>
-</section>
-    
-    
-<section id="h_pages">
+    </section>
+
+    <section id="h_pages">
       <h2>Pages</h2>
-    <p>Topic Keywords:</p>
+      <p>Topic Keywords:</p>
       <ul>
-	<li><strong>Basic common templates:</strong></li>
-	<li><strong>Page elements:</strong></li>
-	<li><strong>Page-level directionality:</strong> Directionality of page elements. Bidirectional behaviour in mixed script texts on the page.</li>
-	<li><strong>Arrangement of elements on the page:</strong></li>
-	<li><strong>Text columns:</strong></li>
-	<li><strong>Header:</strong></li>
-	<li><strong>Footers:</strong> Footnotes and numbering schemes.</li>
-	<li><strong>Illustrations:</strong></li>
-	<li><strong>Tables:</strong> Directional behvaiour of tables. Mixed script text in tables.
-	<li><strong>Page numbers:</strong> Positions of page numbers on the page. Mentioning contemporary and traditional use of Abjad page numbering.</li>
-	<li><strong>Page margins:</strong></li>
-	<li><strong>Positioning and arrangement of content:</strong></li>
-	<li><strong>Pagination rules:</strong></li>
-	<li><strong>Specimens and examples:</strong></li>
+        <li><strong>Basic common templates:</strong></li>
+        <li><strong>Page elements:</strong></li>
+        <li><strong>Page-level directionality:</strong> Directionality of page elements. Bidirectional behaviour in mixed script texts on the page.</li>
+        <li><strong>Arrangement of elements on the page:</strong></li>
+        <li><strong>Text columns:</strong></li>
+        <li><strong>Header:</strong></li>
+        <li><strong>Footers:</strong> Footnotes and numbering schemes.</li>
+        <li><strong>Illustrations:</strong></li>
+        <li><strong>Tables:</strong> Directional behvaiour of tables. Mixed script text in tables.
+        <li><strong>Page numbers:</strong> Positions of page numbers on the page. Mentioning contemporary and traditional use of Abjad page numbering.</li>
+        <li><strong>Page margins:</strong></li>
+        <li><strong>Positioning and arrangement of content:</strong></li>
+        <li><strong>Pagination rules:</strong></li>
+        <li><strong>Specimens and examples:</strong></li>
       </ul>
-</section>
-    
-    
-<section id="h_document">
+    </section>
+
+    <section id="h_document">
       <h2>Document</h2>
-    <p>Topic Keywords:</p> 
+      <p>Topic Keywords:</p>
       <ul>
-	<li><strong>Distinguished requirements:</strong> book/ebook/page</li>
-	<li><strong>Inter-page spacing:</strong></li>
-	<li><strong>First and last pages:</strong> Common practices for first and last pages.</li>
-	<li><strong>Table of Contents and lists:</strong></li>
-	<li><strong>Indexes:</strong> Sorting of names.</li>
-	<li><strong>Appendices:</strong> Bibliographies, glossaries, endnotes, etc.</li>
+        <li><strong>Distinguished requirements:</strong> book/ebook/page</li>
+        <li><strong>Inter-page spacing:</strong></li>
+        <li><strong>First and last pages:</strong> Common practices for first and last pages.</li>
+        <li><strong>Table of Contents and lists:</strong></li>
+        <li><strong>Indexes:</strong> Sorting of names.</li>
+        <li><strong>Appendices:</strong> Bibliographies, glossaries, endnotes, etc.</li>
       </ul>
-</section>
+    </section>
 
+    <section class="appendix" id="glossary">
+      <h2>Glossary</h2>
+      <table class="glossary">
+        <thead>
+          <tr>
+            <th>Term</th>
+            <th>Arabic<span data-lang="zh"></span></th>
+            <th>Persian<span data-lang="zh"></span></th>
+            <th>Definition<span data-lang="zh"></span></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr id="def_justify">
+            <td>Justification</td>
+            <td>ضبط السطور</td>
+            <td>ترازبندی</td>
+            <td>To adjust the length of the line so that it is flush left and right on the measure.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
 
-
-<section class="appendix" id="glossary">
-  <h2>Glossary</h2>
-  <table class="glossary">
-    <thead>
-      <tr>
-        <th>Term</th>
-        <th>Arabic<span data-lang="zh"></span></th>
-        <th>Persian<span data-lang="zh"></span></th>
-        <th>Definition<span data-lang="zh"></span></th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr id="def_justify">
-        <td>Justification</td>
-        <td>ضبط السطور</td>
-        <td>ترازبندی</td>
-        <td>To adjust the length of the line so that it is flush left and right on the measure.</td>
-      </tr>
-    </tbody>
-  </table>
-</section>
-
-
- <section class="appendix" id="acknowledgements">
-  <h2>Acknowledgements</h2>
-  <p>Special thanks to the following people who contributed to this document (contributors' names listed in in alphabetic order).</p>
-  <p class="acknowledgement">This Person, That Person, etc</p>
-  <p data-lang="en">Please find the latest info of the contributors at the <a href="https://github.com/w3c/alreq/graphs/contributors">GitHub contributors list</a>.</p>
-</section>
-  
-</body>
+    <section class="appendix" id="acknowledgements">
+      <h2>Acknowledgements</h2>
+      <p>Special thanks to the following people who contributed to this document (contributors' names listed in in alphabetic order).</p>
+      <p class="acknowledgement">This Person, That Person, etc</p>
+      <p data-lang="en">Please find the latest info of the contributors at the <a href="https://github.com/w3c/alreq/graphs/contributors">GitHub contributors list</a>.</p>
+    </section>
+  </body>
 </html>


### PR DESCRIPTION
I was about to start making some changes to the document for a PR and noticed that our HTML code has some formatting inconsistencies, like this:

``` html
<section id="h_characters">
      <h2>Characters</h2>
    <p>Topic Keywords:</p>
      <ul>
  <li><strong>Characters…
```

Since different people are going to work on this HTML code and we will be sending git diffs using PRs, this can lead to some headaches.

I used the first formatting that came to my mind: two spaces for indentation and no tabs. It’s not important which format we use. Consistency is what matters.
