### PR TITLE
Add an "Arabic Script Overview" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,14 +83,25 @@
       <p>Some text goes here.</p>
   </section>
 </section>
+
+<section id="h_arabic_script_overview">
+	<h2>Arabic Script Overview</h2>
+	<p>Topic Keywords:</p>
+	<ul>
+		<li><strong>Characters:</strong> Listing the characters&mdash;alphabet, diacritics, numerals, and punctuations&mdash;which are used with Arabic script. Distinguishing which character is used with which language. Provide sources for the classification (e.g. CLDR exemplar data).</li>
+		<li><strong>Direction:</strong> Breif description of bidi. Reference to further reading.</li>
+		<li><strong>Joining:</strong> Describe the joining/non-joining behavour and ligatures briefly and refer to Unicode Standard for in-detail description.</li>
+		<li><strong>Diacritics:</strong> Describe diacritics, their lack of effect on the joining, and combining them.</li>
+		<li><strong>Numbers:</strong> Brief description of different sets of numerals and their usage for Arabic and Persian languages.</li>
+	</ul>
+</section>
     
     
-<section id="h_characters">
-      <h2>Characters</h2>
+<section id="h_characters_and_words">
+      <h2>Characters and Words</h2>
     <p>Topic Keywords:</p>
       <ul>
-	<li><strong>Characters in Use:</strong> Listing the characters--alphabet, diacritics, numerals, and punctuations--which are used with Arabic script. Distinguishing which character is used with which language. Provide sources for the classification (e.g. CLDR exemplar data). Address the issue of usage of Arabic numerals vs. Arabic-Indic vs. Eastern Arabic-Indic numerals with text in Arabic and Persian langauge and provide resources and guidelines on how to choose the right set of numerals based on the language.
-	<li><strong>Arrangement and Joining Behaviour:</strong> Describe the joining/non-joining behavour, use of diacritics and combining marks, and ligatures briefly and refer to Unicode Standard for in-detail description. Elaborate of zero-width joining and non-joining behaviour.</li>
+	<li><strong>Arrangement and Joining Behaviour:</strong> Describe different cases of dealing with joining and text alignment, such as behavior of ZWNJ and ZWJ, glyph overlapping, single-glyph styling without breaking joining, and letter-spacing.
 	<li><strong>Spacing:</strong> Use of space as word boundary and exceptions ("و" conjunction in Arabic orthography, "ل" before a non-Arabic script noun). Misuse of space in place of ZWNJ in some Arabic script languages.</li>
 	<li><strong>Font and Typographical considerations:</strong> Common typographical styles and their visual identity. Font size considerations for mixed-script text.</li>
       </ul>
@@ -104,7 +115,7 @@
 	<li><strong>Line composition rules:</strong> Characters which can not appear in start and end of the line. Mid-word and mid-sentence line breaking behaviour.</li>
 	<li><strong>Punctuations:</strong> Use and positioning of punctuation marks in the sentence. Use of paired punctuation marks.</li>
 	<li><strong>Mixed script text:</strong></li>
-	<li><strong>Directionality and bidi:</strong> Breif description of bidi. Special considerations for mixed script text. Reference to further reading.</li>
+	<li><strong>Directionality and bidi:</strong> Special considerations for mixed script text.</li>
 	<li><strong>Paragraph adjustment and alignment:</strong> Paragraph spacing and indentation rules.</li>
 	<li><strong>Tab setting:</strong></li>
 	<li><strong>Justification and Elongation/Tatweel/Kashida:</strong> Common <a href="#def_justify" class="termref">justification</a> methods.</li>


### PR DESCRIPTION
See #12 for the discussion. This section puts a nice introductory
overview on the beginning of the document and allows other parts of the
document to focus only on the issues that they want to talk about.

Some parts of the doucment, now covered here, are removed from other
sections. And now that the chapter "Characters" doesn't focus that much
on characters, it is renamed to "characters and words" to better reflect
its role.
