### PR TITLE
Replace literal quotes with spans

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
 		<section id="h_joining_behavior_of_characters">
 			<h2>Joining Behavior of Characters</h2>
 
-			<p>Arabic script is cursive; i.e, characters are joined to their neighbors. For this purpose, each Arabic letter has at most four different shapes that allows it to join to its neighbors: beside the “isolated” form, there are “initial”, “medial”, and “final” forms. Their purposes, as their names suggest, are as follows:</p>
+			<p>Arabic script is cursive; i.e, characters are joined to their neighbors. For this purpose, each Arabic letter has at most four different shapes that allows it to join to its neighbors: beside the <span class="qterm">isolated</span> form, there are <span class="qterm">initial</span>, <span class="qterm">medial</span>, and <span class="qterm">final</span> forms. Their purposes, as their names suggest, are as follows:</p>
 
 			<ul>
 				<li><strong>Isolated shape:</strong> Used when the letter is not joined to any other letter.</li>
@@ -125,9 +125,9 @@
 				<figcaption>Joining letters by using their various shapes</figcaption>
 			</figure>
 
-			<p>There are different categories of characters based on their joining behavior, but most of the Arabic letters are either “dual joining” or “right joining”. Dual joining characters can join from both sides. Like the character in image 1, these types of characters have all the four shapes mentioned above. Right joining characters only join to their previous (right-side) character. These characters only have isolated and final shapes, for they don’t join to their next character.</p>
+			<p>There are different categories of characters based on their joining behavior, but most of the Arabic letters are either <span class="qterm">dual joining</span> or <span class="qterm">right joining</span>. Dual joining characters can join from both sides. Like the character in image 1, these types of characters have all the four shapes mentioned above. Right joining characters only join to their previous (right-side) character. These characters only have isolated and final shapes, for they don’t join to their next character.</p>
 
-			<p>Almost all the non-alphabetical characters are “non-joining”. The few exceptions will be discussed in this document.</p>
+			<p>Almost all the non-alphabetical characters are <span class="qterm">non-joining</span>. The few exceptions will be discussed in this document.</p>
 
 			<p>Please refer to The Unicode Standard Version 8.0, Section 9.2, for full explanation of Arabic cursive joining.</p>
 		</section>

--- a/local.css
+++ b/local.css
@@ -62,10 +62,10 @@ a.termref:active {
 	border-bottom: 1px dotted #FC0; 
 	}
 
-.qterm:before, .qchar:before { content: "'"; }
-.qterm:after, .qchar:after { content: "'"; }
-.quote:before { content: '"'; }
-.quote:after { content: '"'; }
+.qterm:before, .qchar:before { content: "‘"; }
+.qterm:after, .qchar:after { content: "’"; }
+.quote:before { content: '“'; }
+.quote:after { content: '”'; }
 code { 
 	color: #A52A2A; 
     font-family: Consolas, "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", Monaco, "Courier New", monospace; 


### PR DESCRIPTION
This decision is discussed in part of #13. Using `span`s instead of
putting quotation marks in the text brings flexiblity to changing the
quotes easily and helps with localization of the document to other
languages.

Since these are the first times using these quotation spans, I found out
that the CSS is using straight quotation marks (' and "). I replaced
them with curly quotation marks (‘, ’, “, and ”).
