### PR TITLE
Tidying Up HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,22 +1,19 @@
 <!DOCTYPE html>
-<html lang="en"><head>
-<meta http-equiv="content-type" content="text/html; charset=UTF-8">
 
+<html lang="en">
+<head>
+  <meta http-equiv="content-type"
+        content="text/html; charset=utf-8">
 
-  
-<meta charset="utf-8">
-
-
-  
-<title>Arabic Layout Requirements</title>
-
-
-  
-<script src="https://www.w3.org/Tools/respec/respec-w3c-common" async="" class="remove">
-  </script>
-  
-<script class="remove">
-    var respecConfig = {
+  <title>Arabic Layout Requirements</title>
+  <script src="https://www.w3.org/Tools/respec/respec-w3c-common"
+        async=""
+        class="remove"
+        type="text/javascript">
+</script>
+  <script class="remove"
+        type="text/javascript">
+var respecConfig = {
       // specification status (e.g. WD, LCWD, WG-NOTE, etc.). If in doubt use ED.
       specStatus:           "ED",
       //publishDate:  "2015-07-21",
@@ -66,4002 +63,6060 @@
       // !!!! IMPORTANT !!!! MAKE THE ABOVE BLINK IN YOUR HEAD
     };
   </script>
-  
-<link rel="stylesheet" href="local.css" type="text/css">
-
-
+  <link rel="stylesheet"
+        href="local.css"
+        type="text/css">
 </head>
-<body class="h-entry" role="document" id="respecDocument" style="  color: rgb(0, 0, 0);" alink="#EE0000" link="#0000EE" vlink="#551A8B">
-  
-<div id="abstract">
-    <p>This document describes requirements for the layout and presentation of text in languages
-    that use the Arabic script when they are used by Web standards and technologies, such as HTML,
-    CSS, Mobile Web, Digital Publications, and Unicode.</p>
+
+<body class="h-entry"
+      role="document"
+      id="respecDocument"
+      style=" color: rgb(0, 0, 0);">
+  <div id="abstract">
+    <p>This document describes requirements for the layout and presentation of
+    text in languages that use the Arabic script when they are used by Web
+    standards and technologies, such as HTML, CSS, Mobile Web, Digital
+    Publications, and Unicode.</p>
   </div>
 
+  <div id="sotd">
+    <p>This document describes the basic requirements for Arabic script layout
+    and text support on the Web and in eBooks. These requirements provide
+    information for Web technologies such as CSS, HTML and digital publications
+    about how to support users of Arabic scripts. Currently the document
+    focuses on Standard Arabic and Persian.</p>
 
-  
-<div id="sotd">
-    <p>This document describes the basic requirements for Arabic script layout and text support on
-    the Web and in eBooks. These requirements provide information for Web technologies such as CSS,
-    HTML and digital publications about how to support users of Arabic scripts. Currently the
-    document focuses on Standard Arabic and Persian.</p>
-    <p>The editor's draft of this document is being developed by the <a href="http://www.w3.org/International/groups/arabic-layout/">Arabic Layout Task Force</a>, part of
-    the W3C <a href="http://www.w3.org/International/ig/">Internationalization Interest Group</a>.
-    It is published by the <a href="http://www.w3.org/International/core/">Internationalization
-    Working Group</a>. The end target for this document is a Working Group Note.</p>
+    <p>The editor's draft of this document is being developed by the <a href=
+    "http://www.w3.org/International/groups/arabic-layout/">Arabic Layout Task
+    Force</a>, part of the W3C <a href=
+    "http://www.w3.org/International/ig/">Internationalization Interest
+    Group</a>. It is published by the <a href=
+    "http://www.w3.org/International/core/">Internationalization Working
+    Group</a>. The end target for this document is a Working Group Note.</p>
+
     <div class="note">
-      <p data-lang="en" style="font-weight: bold; font-size: 120%">Sending comments on this
-      document</p>
-      <p data-lang="en">If you wish to make comments regarding this document, please raise them as
-      <a href="https://github.com/w3c/alreq/issues" style="font-size: 120%;">github issues</a> 
-      <!--against the <a href="http://www.w3.org/TR/2015/WD-ilreq-20150721/" style="font-size: 120%">latest dated version in /TR</a>-->.
-      Only send comments by email if you are unable to raise issues on github (see links below).
-      All comments are welcome.</p>
-      <p data-lang="en">To make it easier to track comments, please raise separate issues or emails
-      for each comment, and point to the section you are commenting on&nbsp; using a URL for the
-      dated version of the document.</p>
+      <p data-lang="en"
+         style="font-weight: bold; font-size: 120%">Sending comments on this
+         document</p>
+
+      <p data-lang="en">If you wish to make comments regarding this document,
+      please raise them as <a href="https://github.com/w3c/alreq/issues"
+         style="font-size: 120%;">github issues</a> 
+         <!--against the <a href="http://www.w3.org/TR/2015/WD-ilreq-20150721/" style="font-size: 120%">latest dated version in /TR</a>-->.
+         Only send comments by email if you are unable to raise issues on
+         github (see links below). All comments are welcome.</p>
+
+      <p data-lang="en">To make it easier to track comments, please raise
+      separate issues or emails for each comment, and point to the section you
+      are commenting on&nbsp; using a URL for the dated version of the
+      document.</p>
     </div>
   </div>
 
-
-  
-<section id="h_introduction">
+  <section id="h_introduction">
     <h2>Introduction</h2>
+
     <section id="h_about_this_document">
       <h2>About this document</h2>
+
       <p>Some text goes here.</p>
     </section>
   </section>
 
-
-  
-<section id="h_arabic_script_overview">
+  <section id="h_arabic_script_overview">
     <h2>Arabic Script Overview</h2>
+
     <p>Topic Keywords:</p>
+
     <ul>
-      <li><del><strong>Characters:</strong> Listing the characters—alphabet, diacritics, numerals, and
-      punctuations—which are used with Arabic script. Distinguishing which character is used with
-      which language. Provide sources for the classification (e.g. CLDR exemplar data).</del></li>
-      <li><del><strong>Direction:</strong> Breif description of bidi. Reference to further reading.</del></li>
       <li>
-        <del><strong>Joining:</strong> Describe the joining/non-joining behavour and ligatures
-        briefly and refer to Unicode Standard for in-detail description.</del>
+        <del><strong>Characters:</strong> Listing the characters—alphabet,
+        diacritics, numerals, and punctuations—which are used with Arabic
+        script. Distinguishing which character is used with which language.
+        Provide sources for the classification (e.g. CLDR exemplar data).</del>
       </li>
-      <li><strong>Diacritics:</strong> Describe diacritics, their lack of effect on the joining,
-      and combining them.</li>
-      <li><strong>Numbers:</strong> Brief description of different sets of numerals and their usage
-      for Arabic and Persian languages.</li>
+
+      <li>
+        <del><strong>Direction:</strong> Breif description of bidi. Reference
+        to further reading.</del>
+      </li>
+
+      <li>
+        <del><strong>Joining:</strong> Describe the joining/non-joining
+        behavour and ligatures briefly and refer to Unicode Standard for
+        in-detail description.</del>
+      </li>
+
+      <li><strong>Diacritics:</strong> Describe diacritics, their lack of
+      effect on the joining, and combining them.</li>
+
+      <li><strong>Numbers:</strong> Brief description of different sets of
+      numerals and their usage for Arabic and Persian languages.</li>
     </ul>
+
     <section id="h_encoding">
       <h2>Encoding</h2>
-      <p>Arabic script is encoded in the Unicode standard <em>semantically</em>, meaning that every
-      letter receives only a single Unicode character, no matter how many different contextual
-      shapes it may exhibit.</p>
-      <p>Unicode also has a partial set of <em>non-semantic</em> encoded characters for the Arabic
-      script, under blocks <em>Arabic Presentation Forms-A</em> and <em>Arabic Presentation
-      Forms-B</em>, which are deprecated and should not be used in general interchange.</p>
+
+      <p>Arabic script is encoded in the Unicode standard
+      <em>semantically</em>, meaning that every letter receives only a single
+      Unicode character, no matter how many different contextual shapes it may
+      exhibit.</p>
+
+      <p>Unicode also has a partial set of <em>non-semantic</em> encoded
+      characters for the Arabic script, under blocks <em>Arabic Presentation
+      Forms-A</em> and <em>Arabic Presentation Forms-B</em>, which are
+      deprecated and should not be used in general interchange.</p>
     </section>
+
     <section id="h_direction">
       <h2>Direction</h2>
-      <p>Arabic script is written from right to left. Numbers, even Arabic numbers, are written from left to right, as is text in a script that is normally left-to-right.</p>
-      <p>When the main script is Arabic, the layout and structure of pages and documents are also set from right to left.</p>
-      <p><a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9, Unicode Bidirectional Algorithm</a> details an algorithm for rendering right-to-left text and covers a myriad of situations in mixing different kinds of characters. A simpler explanation of the basics of the algorithm exists in the W3C article <a href="http://www.w3.org/International/articles/inline-bidi-markup/uba-basics">Unicode Bidirectional Algorithm basics</a>. You can refer to these documents for more information about Unicode’s bidirectional algorithm.</p>
-      <p>A brief overview of the bidirectional (<span class="qterm">bidi</span> for short) algorithm follows, because the direction is an essential part of how Arabic script is used.</p>
-      <p>The characters of a text are digitally stored and transferred in the same order that they are typed by a user. This is the order in which the text is read and pronounced by people and held in memory by software applications, as shown in <a href="#order_in_memory"></a> for a sample text.</p>
+
+      <p>Arabic script is written from right to left. Numbers, even Arabic
+      numbers, are written from left to right, as is text in a script that is
+      normally left-to-right.</p>
+
+      <p>When the main script is Arabic, the layout and structure of pages and
+      documents are also set from right to left.</p>
+
+      <p><a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex
+      #9, Unicode Bidirectional Algorithm</a> details an algorithm for
+      rendering right-to-left text and covers a myriad of situations in mixing
+      different kinds of characters. A simpler explanation of the basics of the
+      algorithm exists in the W3C article <a href=
+      "http://www.w3.org/International/articles/inline-bidi-markup/uba-basics">Unicode
+      Bidirectional Algorithm basics</a>. You can refer to these documents for
+      more information about Unicode’s bidirectional algorithm.</p>
+
+      <p>A brief overview of the bidirectional (<span class="qterm">bidi</span>
+      for short) algorithm follows, because the direction is an essential part
+      of how Arabic script is used.</p>
+
+      <p>The characters of a text are digitally stored and transferred in the
+      same order that they are typed by a user. This is the order in which the
+      text is read and pronounced by people and held in memory by software
+      applications, as shown in <a href="#order_in_memory"></a> for a sample
+      text.</p>
+
       <figure id="order_in_memory">
-        <img src="images/order-in-memory.svg" alt="The order of characters in memory" width="90%">
+        <img src="images/order-in-memory.svg"
+                alt="The order of characters in memory">
+
         <figcaption>The order of characters in memory</figcaption>
       </figure>
-      <p>But the order used when displaying text is different. The purpose of the bidi algorithm is to find display positions for the characters of a text. These positions are solely used for displaying texts. <a href="#order_when_displayed"></a> shows the same sample text when prepared for display with the bidi algorithm.</p>
+
+      <p>But the order used when displaying text is different. The purpose of
+      the bidi algorithm is to find display positions for the characters of a
+      text. These positions are solely used for displaying texts. <a href=
+      "#order_when_displayed"></a> shows the same sample text when prepared for
+      display with the bidi algorithm.</p>
+
       <figure id="order_when_displayed">
-        <img src="images/order-when-displayed.svg" alt="The order of characters when displayed" width="90%">
+        <img src="images/order-when-displayed.svg"
+                alt="The order of characters when displayed">
+
         <figcaption>The order of characters when displayed</figcaption>
       </figure>
-      <p>An initial step of the process involves determining each paragraph’s <span class="qterm">base direction</span>: whether the paragraph is left-to-right or right-to-left. The base direction is either explicitly set by the author, inherited from the page, or (typically for user-generated content) detected based on the content of the paragraph. The base direction has two important uses later in the process.</p>
-      <p>The next step is to split the text into <span class="qterm">directional runs</span>. Each directional run is a sequence of characters with the same direction.</p>
+
+      <p>An initial step of the process involves determining each paragraph’s
+      <span class="qterm">base direction</span>: whether the paragraph is
+      left-to-right or right-to-left. The base direction is either explicitly
+      set by the author, inherited from the page, or (typically for
+      user-generated content) detected based on the content of the paragraph.
+      The base direction has two important uses later in the process.</p>
+
+      <p>The next step is to split the text into <span class=
+      "qterm">directional runs</span>. Each directional run is a sequence of
+      characters with the same direction.</p>
+
       <figure id="directional_runs">
-        <img src="images/directional-runs.svg" alt="Splitting a text into 3 directional runs" width="90%">
+        <img src="images/directional-runs.svg"
+                alt="Splitting a text into 3 directional runs">
+
         <figcaption>Splitting a text into 3 directional runs</figcaption>
       </figure>
-      <p>Inside each run, all the characters follow the same order. The runs themselves are ordered for visual representation from left to right or from right to left, depending on the base direction of the paragraph. <a href="#order_of_directional_runs"></a> demonstrates an example of this. This is the first effect of the base direction.</p>
+
+      <p>Inside each run, all the characters follow the same order. The runs
+      themselves are ordered for visual representation from left to right or
+      from right to left, depending on the base direction of the paragraph.
+      <a href="#order_of_directional_runs"></a> demonstrates an example of
+      this. This is the first effect of the base direction.</p>
+
       <figure id="order_of_directional_runs">
-        <img src="images/order-of-directional-runs.svg" alt="The effect of base direction on the order of runs" width="90%">
-        <figcaption>The effect of base direction on the order of runs</figcaption>
+        <img src="images/order-of-directional-runs.svg"
+                alt="The effect of base direction on the order of runs">
+
+        <figcaption>The effect of base direction on the order of
+        runs</figcaption>
       </figure>
-      <p>Unicode has a <span class="qterm">bidi category</span> property defined for each character that is used to determine the direction of each character. All the Arabic letters are marked as right-to-left characters, while Latin characters have the left-to-right category.</p>
-      <p>Some characters, mostly punctuations, are <span class="qterm">neutral</span>. The direction of these characters is derived from their surrounding characters. If a neutral character is surrounded by characters of the same direction (e.g. an space surrounded by Arabic letters), it gets the direction of its neighbors. Otherwise (e.g. a space between an Arabic and a Latin, or a neutral character appearing at the start or the end of a paragraph), the neutral character gets its direction from the paragraph’s base direction. This is another effect of the base direction in the bidi algorithm.</p>
-      <p>The above explanation of the bidi algorithm is highly simplified, to convey only the essentials of how Arabic text is transformed for rendering. The actual algorithm deals with many more character types and edge cases. Please refer to <a href="http://www.w3.org/International/articles/inline-bidi-markup/uba-basics">Unicode Bidirectional Algorithm basics</a> for more information or <a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9, Unicode Bidirectional Algorithm</a> for the official detailed documentation.</p>
+
+      <p>Unicode has a <span class="qterm">bidi category</span> property
+      defined for each character that is used to determine the direction of
+      each character. All the Arabic letters are marked as right-to-left
+      characters, while Latin characters have the left-to-right category.</p>
+
+      <p>Some characters, mostly punctuations, are <span class=
+      "qterm">neutral</span>. The direction of these characters is derived from
+      their surrounding characters. If a neutral character is surrounded by
+      characters of the same direction (e.g. an space surrounded by Arabic
+      letters), it gets the direction of its neighbors. Otherwise (e.g. a space
+      between an Arabic and a Latin, or a neutral character appearing at the
+      start or the end of a paragraph), the neutral character gets its
+      direction from the paragraph’s base direction. This is another effect of
+      the base direction in the bidi algorithm.</p>
+
+      <p>The above explanation of the bidi algorithm is highly simplified, to
+      convey only the essentials of how Arabic text is transformed for
+      rendering. The actual algorithm deals with many more character types and
+      edge cases. Please refer to <a href=
+      "http://www.w3.org/International/articles/inline-bidi-markup/uba-basics">Unicode
+      Bidirectional Algorithm basics</a> for more information or <a href=
+      "http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9, Unicode
+      Bidirectional Algorithm</a> for the official detailed documentation.</p>
     </section>
+
     <section id="h_joining">
       <h2>Joining</h2>
+
       <section id="h_joining_behavior_of_characters">
         <h2>Joining Behavior of Characters</h2>
-        <p>Arabic script is cursive; i.e, characters are joined to their neighbors. For this
-        purpose, each Arabic letter has at most four different shapes that allows it to join to its
-        neighbors: beside the <span class="qterm">isolated</span> form, there are <span class="qterm">initial</span>, <span class="qterm">medial</span>, and <span class="qterm">final</span> forms. Their purposes, as their names suggest, are as follows:</p>
+
+        <p>Arabic script is cursive; i.e, characters are joined to their
+        neighbors. For this purpose, each Arabic letter has at most four
+        different shapes that allows it to join to its neighbors: beside the
+        <span class="qterm">isolated</span> form, there are <span class=
+        "qterm">initial</span>, <span class="qterm">medial</span>, and
+        <span class="qterm">final</span> forms. Their purposes, as their names
+        suggest, are as follows:</p>
+
         <ul>
-          <li><strong>Isolated shape:</strong> Used when the letter is not joined to any other
-          letter.</li>
-          <li><strong>Initial shape:</strong> Used when the letter is joined only to its next
-          (left-side) letter.</li>
-          <li><strong>Medial shape:</strong> Used when the letter is joined from its both
-          sides.</li>
-          <li><strong>Final shape:</strong> Used when the letter is joined only to its previous
-          (right-side) letter.</li>
+          <li><strong>Isolated shape:</strong> Used when the letter is not
+          joined to any other letter.</li>
+
+          <li><strong>Initial shape:</strong> Used when the letter is joined
+          only to its next (left-side) letter.</li>
+
+          <li><strong>Medial shape:</strong> Used when the letter is joined
+          from its both sides.</li>
+
+          <li><strong>Final shape:</strong> Used when the letter is joined only
+          to its previous (right-side) letter.</li>
         </ul>
-        <p> shows all four shapes of character <span class="uname">U+0645 ARABIC LETTER MEEM</span> (<span dir="rtl" lang="ar">م</span>).</p>
+
+        <p>shows all four shapes of character <span class="uname">U+0645 ARABIC
+        LETTER MEEM</span> (<span dir="rtl"
+              lang="ar">م</span>).</p>
+
         <figure id="letter_shapes">
-          <img src="images/letter-shapes.png" alt="Four different shapes for joining to previous or succeeding letters" width="90%">
-          <figcaption>
-            Four different shapes for joining to previous or succeeding letters
-          </figcaption>
+          <img src="images/letter-shapes.png"
+                  alt=
+                  "Four different shapes for joining to previous or succeeding letters">
+
+          <figcaption>Four different shapes for joining to previous or
+          succeeding letters</figcaption>
         </figure>
-        <p>For each Arabic letter, based on the joining behavior of its neighbors, one of its
-        shapes is used in writing.  demonstrates how letters join to
-        form a word.</p>
+
+        <p>For each Arabic letter, based on the joining behavior of its
+        neighbors, one of its shapes is used in writing. demonstrates how
+        letters join to form a word.</p>
+
         <figure id="joining_process">
-          <img src="images/joining-process.png" alt="Joining letters by using their various shapes" width="90%">
-          <figcaption>
-            Joining letters by using their various shapes
-          </figcaption>
+          <img src="images/joining-process.png"
+                  alt="Joining letters by using their various shapes">
+
+          <figcaption>Joining letters by using their various
+          shapes</figcaption>
         </figure>
-        <p>There are different categories of characters based on their joining behavior, but most
-        of the Arabic letters are either <span class="qterm">dual joining</span> or <span class="qterm">right joining</span>. Dual joining characters can join from both sides. Like the
-        character in image 1, these types of characters have all the four shapes mentioned above.
-        Right joining characters only join to their previous (right-side) character. These
-        characters only have isolated and final shapes, for they don’t join to their next
-        character.</p>
+
+        <p>There are different categories of characters based on their joining
+        behavior, but most of the Arabic letters are either <span class=
+        "qterm">dual joining</span> or <span class="qterm">right
+        joining</span>. Dual joining characters can join from both sides. Like
+        the character in image 1, these types of characters have all the four
+        shapes mentioned above. Right joining characters only join to their
+        previous (right-side) character. These characters only have isolated
+        and final shapes, for they don’t join to their next character.</p>
+
         <figure id="right_joining_letter">
-          <img src="images/right-joining-letter.svg" alt="Right-joining letters only have two forms of final and isolated." width="50%">
-          <figcaption>Right-joining letters only have two forms of final and isolated.</figcaption>
+          <img src="images/right-joining-letter.svg"
+                  alt=
+                  "Right-joining letters only have two forms of final and isolated.">
+
+          <figcaption>Right-joining letters only have two forms of final and
+          isolated.</figcaption>
         </figure>
-        <p>Almost all the non-alphabetical characters are <span class="qterm">non-joining</span>.
-        The few exceptions will be discussed in this document.</p>
-        <p>Please refer to The Unicode Standard Version 8.0, Section 9.2, for full explanation of
-        Arabic cursive joining.</p>
+
+        <p>Almost all the non-alphabetical characters are <span class=
+        "qterm">non-joining</span>. The few exceptions will be discussed in
+        this document.</p>
+
+        <p>Please refer to The Unicode Standard Version 8.0, Section 9.2, for
+        full explanation of Arabic cursive joining.</p>
+
         <section id="h_joining_and_spacing">
           <h2>Joining and Intra-Word Spaces</h2>
-          <p>The only spaces inside Arabic words are created near characters that are not
-            dual-joining. When adjusing intra-word spaces (i.e. the space inside the words) only
-            these spaces can be adjusted. Moving two joined characters closer to or further from
-            each other creates undesirable results.</p>
+
+          <p>The only spaces inside Arabic words are created near characters
+          that are not dual-joining. When adjusing intra-word spaces (i.e. the
+          space inside the words) only these spaces can be adjusted. Moving two
+          joined characters closer to or further from each other creates
+          undesirable results.</p>
         </section>
       </section>
+
       <section id="h_ligatures">
         <h2>Ligatures</h2>
-        <p>Almost all the writing styles of Arabic script use a special shape when letters
-        <span class="lettername">lam</span> and <span class="lettername">alef</span> are joined.
-        Most Arabic fonts include mandatory ligatures for this combination. Ignoring this ligature,
-        as shown in , leads to wrong rendering of text.</p>
+
+        <p>Almost all the writing styles of Arabic script use a special shape
+        when letters <span class="lettername">lam</span> and <span class=
+        "lettername">alef</span> are joined. Most Arabic fonts include
+        mandatory ligatures for this combination. Ignoring this ligature, as
+        shown in , leads to wrong rendering of text.</p>
+
         <figure id="laam-alef-ligature">
-          <img src="images/laam-alef-ligature.png" alt="Correct and wrong ways of rendering letter lam followed by letter alef" width="90%">
-          <figcaption>
-            Correct and wrong ways of rendering letter <span class="lettername">lam</span> followed
-            by letter <span class="lettername">alef</span>
-          </figcaption>
+          <img src="images/laam-alef-ligature.png"
+                  alt=
+                  "Correct and wrong ways of rendering letter lam followed by letter alef">
+
+          <figcaption>Correct and wrong ways of rendering letter <span class=
+          "lettername">lam</span> followed by letter <span class=
+          "lettername">alef</span></figcaption>
         </figure>
-        <p>This shape is not limited to the combination of <span class="uname">U+0644 ARABIC LETTER
-        LAM</span> (<span dir="rtl" lang="ar">ل</span>) with <span class="uname">U+0627 ARABIC
-        LETTER ALEF</span> (<span dir="rtl" lang="ar">ا</span>). Variations of letter <span class="lettername">alef</span> such as <span class="uname">U+0622 ARABIC LETTER ALEF WITH MADDA
-        ABOVE</span> (<span dir="rtl" lang="ar">آ</span>) and <span class="uname">U+0623 ARABIC
-        LETTER ALEF WITH HAMZA ABOVE</span> (<span dir="rtl" lang="ar">أ</span>) and also
-        variations of letter <span class="lettername">lam</span> follow the same rules as well.
-        Combination with diacritics does not affect these ligatures. Each of these ligatures also
-        provides a special shape for joining from its right side (to the preceding letter).</p>
+
+        <p>This shape is not limited to the combination of <span class=
+        "uname">U+0644 ARABIC LETTER LAM</span> (<span dir="rtl"
+              lang="ar">ل</span>) with <span class="uname">U+0627 ARABIC LETTER
+              ALEF</span> (<span dir="rtl"
+              lang="ar">ا</span>). Variations of letter <span class=
+              "lettername">alef</span> such as <span class="uname">U+0622
+              ARABIC LETTER ALEF WITH MADDA ABOVE</span> (<span dir="rtl"
+              lang="ar">آ</span>) and <span class="uname">U+0623 ARABIC LETTER
+              ALEF WITH HAMZA ABOVE</span> (<span dir="rtl"
+              lang="ar">أ</span>) and also variations of letter <span class=
+              "lettername">lam</span> follow the same rules as well.
+              Combination with diacritics does not affect these ligatures. Each
+              of these ligatures also provides a special shape for joining from
+              its right side (to the preceding letter).</p>
       </section>
     </section>
 
-
-
-
-<section id="h_font_and_typographical_considerations">
-<h2><a href="#h_font_and_typographical_considerations">Font and
-  Typographical considerations</a></h2>
-
-  <section id="h_arabic_style_and_calligraphy">
-  <h3>Arabic Style and Calligraphy</h3>
-
-  <p>Arabic styling and writing has its origins in Islamic art and
-  civilization, and was widely used to decorate mosques and palaces,
-  as well as to create beautiful manuscripts and books, and especially to copy
-  the <em>Kor'an</em>. Arabic script is cursive, making it viable to
-  support different geometric shapes overlapping and composition.
-  Words can be written in a very condensed form as well as
-  stretched into elongated shapes, and the scribes and artists of
-  Islam labored with passion to take advantage of all these
-  possibilities.</p>
-<p>
-
-  </p>
-<p>From the beginning of Arabic calligraphy, two tendencies or
-  two types of styles can be seen emerging: writing for the
-  decoration of mosques and sculptures, which was complex and highly decorative,
-  and writing styles reserved for writing the <em>Kor'an</em>, which were easier
-  to use and more readable.</p>
-<p>
-
-  </p>
-<p>Writing styles then evolved under the influences of
-  cultural diversity, leading to regional calligraphic schools and
-  styles (<em>Kufi</em> in Iraq, <em>Farsi</em> and <em>Taʻliq</em> in
-  Persia, or <em>Diwani</em> in Turkey). Additional differences arose depending on the purpose of writing,
-  such as the copying and dissemination of the <em>Korʼan</em>.</p>
-<p>
-
-  </p>
-<p>In general we group under the generic term <em><strong>Naskh</strong></em>
-  (copy/inscription) the scripts which are meant for reading at
-  smaller sizes and are suitable for books and texts to be read, e.g. the
-  <em>Korʼan</em>, and as <em><strong>Kufic</strong></em> the highly stylized font styles used for ornamentation and more styled writings.
- Nevertheless, the rich evolution of the Arabic script led to the 
-distinctive enumeration of a number of additional named styles.<br>
-Two other styles are used as synonyms for <em>Kufic</em> and <em>Naskh</em>: <em>Mabsut</em> (<em>wa mustaqīm</em>) is a form of style that is straight angled and elongated, [which dominated the copies of <em>Korʼan</em> in eighth and ninth centuries], and <em>Muqawwar</em> (<em>wa mudawar</em>) is a form of style that is curved and rounded.</p>
-
-
-</section>
-
-
-
-
-<section id="h_different_writing_styles">
-  <h3>Different Writing Styles</h3>
-
-  <p>Basics and principles of Arabic writing were  defined by
-  <em>Ibn Moqlah</em> (886-940 Higra), who
-  defined six styles of writing: <em>Kufi</em>, <em>Thuluth</em>,
-  <em>Naskh</em>, <em>Ruqʻa</em>, <em>Taʻliq</em> and  <em>Diwani</em>.</p>
-
-  
-<dl>
-<img alt="Arabic writing styles" src="images/ArabicWritingStyles.png" style=" width: 373px; height: 397px;" align="right">
-    <dt>Kufi  (كوفي)</dt>
-
-    <dd>One of the
-    oldest and best known Arabic scripts. It is characterized by
-    its decorative and pronounced geometric forms, well adapted for
-    architectural designs. The style grew  with the beginning of
-    Islam to satisfy a need for Muslims to codify the Kor'an. <br>
-</dd>
-
-    <dt>Thuluth  (ثلث)</dt>
-
-    <dd>
- (The third.) Recognizable by the fact that the letters and words are highly
-    interleaved in its complex form. May be the most difficult style to 
-write (requiring a significant amount of skill), both in terms of its 
-letters and in terms
-    of its structure and composition.</dd>
-
-    <dt>Naskh  (نسخ)</dt>
-
-    <dd> One of
-    the clearest styles of all, with clearly distinguished letters
-    which facilitate  reading and  pronunciation. Can be
-    written at small sizes (traditionally using pens made of reeds and
-    ink), which suits  the production of longer texts used for boards
-    and books intended for the general population, especially the
-    Kor'an.<del></del></dd>
-
-    <dt>Ruqʻa (رقعة‎)</dt>
-
-    <dd> A handwritten style still commonly used in Arabic countries, and recognisable by its bold-like letters written above the writing line.  
-    Designed to be used for education, for everyday writing
-    and adopted in the offices (<em>Diwan</em>) of the Ottoman
-    Empire. One of it's feature is that calligraphers have kept it and did not derived variations from it</dd>
-
-    <dt>Taʻlīq  (تعليق)</dt>
-
-    <dd> Also known as  <em>Farsi </em>(Iran), <em>Taʻlīq</em> (hanging) combines <em>Naskh</em> and <em>Riqaʻ</em>.
-    A beautiful script characterized by the precision and stretch of
-    its letters, its clarity, and its lack of complexity. Designed for Persian language, until
-    replaced by <em>Nastaʻlīq</em></dd>
-
-    <dt>Diwani (ديواني)<br>
-</dt>
-
-    <dd> Used
-    by the Ottman court (<em>Diwan</em>) to write official documents.
-    Some variations of it are still in use today (e.g. hand written documents by some
-    religious officials).</dd>
-</dl>
-<p>We can add other font styles to this list, such as the following.</p>
-<dl>
-
-
-
-    <dt>Nasta'liq or Farissi (فارسي)<br>
-</dt>
-
-    <dd>&nbsp;Persian version of <em>Taʻliq</em>, derived from <em>Naskh</em> and
-    <em>Taaʻliq</em> and developed in the 8th and 9th centuries. It
-    is like a <em>Taaʻliq</em> but easier to write and read.</dd>
-
-    <dt>Rabat aka  Maghribi&nbsp; (رباط او مغربي‎)<br>
-</dt>
-
-    <dd><img style="width: 214px; height: 53px;" src="images/basmalaMaghribi.png" alt="Maghribi script" align="right">
-    Western Islamic world of North Africa and Spain. Used for
-    writing the Kor'an as well as other scientific, legal and
-    religious manuscripts. Used in some very official printings in Morocco. <br>
-</dd>
-  
-</dl>
-
-</section>
-
-
-<section id="h_arabic_script_and_typography">
-  <h3>Arabic Script and Typography</h3>
-
-  
-<p>Arabic script has some characteristics that are challenging for 
-Typographer and font designers. Examples bellow, shows some 
-characteristics should be handled carefully. How could typography, which came late
-  to Arabic world, then follow the tradition of the many authors /
-  artists who manually shaped the Arabic writing over decades? even
-  in it's simplest <span style="font-style: italic;">Naskh</span> style?
-
-  </p>
-
-
-<ol>
-  <li>
-  <p><strong>1. Multi-level baselines </strong></p>
-
-  <p>Letters may  join through a finely inclined line</p>
-
-  <div style="margin-left: 40px;">
-    <img style=" width: 132px; height: 62px;" alt="slope baseline" src="images/yastabchiro.jpg">
-  </div>
-
-  <p>or  two, square-ended lines</p>
-
-  <div style="margin-left: 40px;">
-    <img style=" width: 92px; height: 79px;" alt="two level baselin" src="images/yastami3o.jpg"><br>
-    </div>
-  Multilevel baselines don't occur in all fonts. The above examples use 
-the Arabic Typesetting font. Compare those examples to to more typical 
-fonts:<br>
-
-  <p style="margin-left: 40px;"><img style="width: 110px; height: 93px;" alt="normal Font" src="images/yastabchiroNormal.jpg"></p>
-</li>
-<li>
-  <p><strong>2. Multi-context joining</strong></p>
-
-  <p>Rendering of letters depends not only on their place in the 
-  word (initial, medial, final) but also on their neighboring letters,
-  i.e. the letter they join with. Each letter has a different
-  appearance in each combination.</p>
-
-<figure>
-    <img style="width: 324px; height: 79px;" alt="Different initial shape of noon" src="images/differentInitialNoon.jpg">
-    <figcaption>Initial letter noon, showing many
-  different forms.</figcaption>
-  </figure>
-
-
-  <p>Fonts don't always comply with or respect this kind of
-    <span class="qterm">tuning</span>.  To do so, fonts need many glyphs in order to adapt to
-  each context. In more modern typefaces some of these connections are
-  implemented by ligatures, but ligatures can't capture or cover all
-  joining behavior.</p>
-
-  <p>In the two left most words, the initial noon differs
-  in that one raises a kind of stroke. This property of raising a
-  stroke is common for a number of letters (beh, teh, noon, theh) which 
-  are taller than their connected letters in order to be distinguished
-  in some contexts, such as<img style="width: 37px; height: 31px;" alt="Beh with stroke before seen" src="images/bsl.jpg" align="middle"> vs. <img style="width: 43px; height: 39px;" alt="Beh without stroke after seen" src="images/sbl.jpg" align="middle"> , or to resolve ambiguity. See also the section about teeth letters
-  below.</p>
-</li>
-<li>
-  <p><strong>3. Words as groups of letters<br></strong></p>
-
-  <p>A word shape is not (only) a "horizontal" connections of
-  letters, but of groups of letters (syntagmes??).</p>
-
-  <p>Example two words in some nice Naskh font.</p>
-
-  <table  style="margin-left: 40px;">
-    <caption align="bottom">
-      Groups of letters are colored blue or red
-    </caption>
-
-    <tbody>
-      <tr>
-        <td style=" text-align: center; width: 40%;"><img style="width: 76px; height: 46px;" alt="Aleph and two groups of letters to form a word" src="images/barmajaAmiri.jpg"></td>
-
-        <td style="vertical-align: top;"><br>
-</td>
-
-        <td style="text-align: center;width:40%;"><img style=" width: 127px; height: 57px;" alt="two other group of letters" src="images/stimrarihimaArabicTypesetting.jpg"></td>
-      </tr>
-    </tbody>
-  </table>
-
-  <p>To compare with the same words in more usual font:</p>
-
-  <table style="margin-left: 40px;">
-    <caption align="bottom">
-      Can't really say letter groups. Rather a "horizontal sequence
-      of letters of almost same width".
-    </caption>
-
-    <tbody>
-      <tr>
-        <td style="text-align: center; width:40%;"><img style=" width: 98px; height: 43px;" alt="same word in more normal font" src="images/barmajaDefault.png"></td>
-
-        <td style=" text-align: center; width: 40%;"><img style=" width: 144px; height: 46px;" alt="same word in default font" src="images/stimrarihimaDefault.jpg"></td>
-      </tr>
-    </tbody>
-  </table>
-
-  <p>Group combinations cannot be covered by general or usual
-  ligatures.</p>
-
-  <p><strong>4. Vertical</strong>
-  <strong>joining</strong></p>
-
-  <p>Groups of letters may also join vertically (top down) instead
-  of right to left. And not all fonts permit this.</p>
-
-  <table style="margin-left: 40px;">
-    <tbody>
-      <tr>
-        <td style=" text-align: center;"><img style="width: 65px; height: 70px;" alt="Vertical joining" src="images/vertivalJoin.jpg" align="middle"></td>
-
-        <td style=" text-align: center;">vs.</td>
-
-        <td style=" text-align: center;"><img style="width: 69px; height: 46px;" alt="horizontal joing" src="images/horizontalJoin.jpg" align="middle"></td>
-      </tr>
-
-      <tr>
-        <td style="text-align: center;">Joining happens almost
-        vertical</td>
-
-        <td>
-</td>
-
-        <td style="text-align: center;">Joining happens
-        horizontal</td>
-      </tr>
-    </tbody>
-  </table>      
-
-
-  <p>Once again, some fonts try standard ligatures, but this is not
-  ligature. This is rather (good) writing practice/style.</p>
-
-  <p>One should note that all this characteristics has not only an
-  aesthetic side, but also play a role in justification. It is at
-  the discretion of (hand writing) authors to chose the best kind
-  of joining to suit the desired line width. Should then be a
-  general rule on that. But  to achieve such justification
-  would require  sophisticated algorithms.</p>
-
-  <p><strong>5. The so called teeth letters.</strong></p>
-
-  <p>Letters having uniform medial shape, align in a kind of
-  teeth.</p>
-
-  <div style="margin-left: 40px;">
-    <img style=" width: 276px; height: 74px;" alt="Teeth letters" src="images/teeth.jpg">
-  </div>
-
-  <p>Even in the teeth context letter shape may vary. It's not the
-  same letters (in red) which raise the stroke in the two
-  figures.</p>
-</li>
-</ol>
-  
-</section>
-
-<section id="h_fonts">
-  <h3><span style="font-weight: bold;">Fonts</span></h3>
-<p>Arabic script 
-counts 26 letters, and mostly 19 basic shapes. Since letters change 
-according to their position in the word, Arabic set of glyph may range 
-to more than one hundred shapes. If one count possible ligatures, and 
-different combination of joining forms (see above), the number of glyph 
-can increase further. Not sure that typeface design can accommodate all needs, even though some present typefaces can run hundred of shapes.</p>
-
-<p>
-Early typefaces, some still in use today, were designed with some 
-facilities. Designer of those differs in their simplification 
-hypothesis. For example, one of the first approach is to use "type writer style", 
-that is a same glyph for different positions in a word. This is the case for initial 
-and medial shape for most of the letters (example here). It is generally the browser 
-default font for Arabic script. A more unifying approach is the use of a single and detached 
-glyph for each letter without joining (todo example here). Other approach were used resulting 
-in more or less visually practical fonts.</p>
-
-<p>
-Nowadays, there is a large choice of fonts, and one can choose the
- font that best suits to one's typographical desire. However, one may 
-also wishes to take into account some non typographical 
-considerations like: (TBD later on)</p>
-
-<ul>
-  <li>Accessibility (readability and visibility) ... </li>
-  <li>The kind of device with small screen (for example, larger loop and teeth height, small descenders etc...), although font actually appear better on smartphones</li>
-  <li>Font style for titles and banners and alike (small number of words), may differ from the style for content text (long text).</li>
-  <li>Shapes and proportions (the size issue) in mixed texts</li>
-  <li>Some fonts might give another opportunity for line justification than the one based on word spacing (todo example MHMD).
-  </li>
-  <li>etc...</li>
-</ul>
-</section>
+    <section id="h_font_and_typographical_considerations">
+      <h2><a href="#h_font_and_typographical_considerations">Font and
+      Typographical considerations</a></h2>
+
+      <section id="h_arabic_style_and_calligraphy">
+        <h3>Arabic Style and Calligraphy</h3>
+
+        <p>Arabic styling and writing has its origins in Islamic art and
+        civilization, and was widely used to decorate mosques and palaces, as
+        well as to create beautiful manuscripts and books, and especially to
+        copy the <em>Kor'an</em>. Arabic script is cursive, making it viable to
+        support different geometric shapes overlapping and composition. Words
+        can be written in a very condensed form as well as stretched into
+        elongated shapes, and the scribes and artists of Islam labored with
+        passion to take advantage of all these possibilities.</p>
+
+        <p>From the beginning of Arabic calligraphy, two tendencies or two
+        types of styles can be seen emerging: writing for the decoration of
+        mosques and sculptures, which was complex and highly decorative, and
+        writing styles reserved for writing the <em>Kor'an</em>, which were
+        easier to use and more readable.</p>
+
+        <p>Writing styles then evolved under the influences of cultural
+        diversity, leading to regional calligraphic schools and styles
+        (<em>Kufi</em> in Iraq, <em>Farsi</em> and <em>Taʻliq</em> in Persia,
+        or <em>Diwani</em> in Turkey). Additional differences arose depending
+        on the purpose of writing, such as the copying and dissemination of the
+        <em>Korʼan</em>.</p>
+
+        <p>In general we group under the generic term
+        <em><strong>Naskh</strong></em> (copy/inscription) the scripts which
+        are meant for reading at smaller sizes and are suitable for books and
+        texts to be read, e.g. the <em>Korʼan</em>, and as
+        <em><strong>Kufic</strong></em> the highly stylized font styles used
+        for ornamentation and more styled writings. Nevertheless, the rich
+        evolution of the Arabic script led to the distinctive enumeration of a
+        number of additional named styles.<br>
+        Two other styles are used as synonyms for <em>Kufic</em> and
+        <em>Naskh</em>: <em>Mabsut</em> (<em>wa mustaqīm</em>) is a form of
+        style that is straight angled and elongated, [which dominated the
+        copies of <em>Korʼan</em> in eighth and ninth centuries], and
+        <em>Muqawwar</em> (<em>wa mudawar</em>) is a form of style that is
+        curved and rounded.</p>
+      </section>
+
+      <section id="h_different_writing_styles">
+        <h3>Different Writing Styles</h3>
+
+        <p>Basics and principles of Arabic writing were defined by <em>Ibn
+        Moqlah</em> (886-940 Higra), who defined six styles of writing:
+        <em>Kufi</em>, <em>Thuluth</em>, <em>Naskh</em>, <em>Ruqʻa</em>,
+        <em>Taʻliq</em> and <em>Diwani</em>.</p><img alt=
+        "Arabic writing styles"
+                 src="images/ArabicWritingStyles.png"
+                 style="width: 373px; height: 397px; float: right;">
+
+        <dl>
+          <dt>Kufi (كوفي)</dt>
+
+          <dd>One of the oldest and best known Arabic scripts. It is
+          characterized by its decorative and pronounced geometric forms, well
+          adapted for architectural designs. The style grew with the beginning
+          of Islam to satisfy a need for Muslims to codify the Kor'an.<br></dd>
+
+          <dt>Thuluth (ثلث)</dt>
+
+          <dd>(The third.) Recognizable by the fact that the letters and words
+          are highly interleaved in its complex form. May be the most difficult
+          style to write (requiring a significant amount of skill), both in
+          terms of its letters and in terms of its structure and
+          composition.</dd>
+
+          <dt>Naskh (نسخ)</dt>
+
+          <dd>One of the clearest styles of all, with clearly distinguished
+          letters which facilitate reading and pronunciation. Can be written at
+          small sizes (traditionally using pens made of reeds and ink), which
+          suits the production of longer texts used for boards and books
+          intended for the general population, especially the Kor'an.</dd>
+
+          <dt>Ruqʻa (رقعة‎)</dt>
+
+          <dd>A handwritten style still commonly used in Arabic countries, and
+          recognisable by its bold-like letters written above the writing line.
+          Designed to be used for education, for everyday writing and adopted
+          in the offices (<em>Diwan</em>) of the Ottoman Empire. One of it's
+          feature is that calligraphers have kept it and did not derived
+          variations from it</dd>
+
+          <dt>Taʻlīq (تعليق)</dt>
+
+          <dd>Also known as <em>Farsi</em> (Iran), <em>Taʻlīq</em> (hanging)
+          combines <em>Naskh</em> and <em>Riqaʻ</em>. A beautiful script
+          characterized by the precision and stretch of its letters, its
+          clarity, and its lack of complexity. Designed for Persian language,
+          until replaced by <em>Nastaʻlīq</em></dd>
+
+          <dt>Diwani (ديواني)<br></dt>
+
+          <dd>Used by the Ottman court (<em>Diwan</em>) to write official
+          documents. Some variations of it are still in use today (e.g. hand
+          written documents by some religious officials).</dd>
+        </dl>
+
+        <p>We can add other font styles to this list, such as the
+        following.</p>
+
+        <dl>
+          <dt>Nasta'liq or Farissi (فارسي)<br></dt>
+
+          <dd>&nbsp;Persian version of <em>Taʻliq</em>, derived from
+          <em>Naskh</em> and <em>Taaʻliq</em> and developed in the 8th and 9th
+          centuries. It is like a <em>Taaʻliq</em> but easier to write and
+          read.</dd>
+
+          <dt>Rabat aka Maghribi&nbsp; (رباط او مغربي‎)<br></dt>
+
+          <dd><img style="width: 214px; height: 53px; float: right;"
+               src="images/basmalaMaghribi.png"
+               alt="Maghribi script"> Western Islamic world of North Africa and
+               Spain. Used for writing the Kor'an as well as other scientific,
+               legal and religious manuscripts. Used in some very official
+               printings in Morocco.<br></dd>
+        </dl>
+      </section>
+
+      <section id="h_arabic_script_and_typography">
+        <h3>Arabic Script and Typography</h3>
+
+        <p>Arabic script has some characteristics that are challenging for
+        Typographer and font designers. Examples bellow, shows some
+        characteristics should be handled carefully. How could typography,
+        which came late to Arabic world, then follow the tradition of the many
+        authors / artists who manually shaped the Arabic writing over decades?
+        even in it's simplest <span style="font-style: italic;">Naskh</span>
+        style?</p>
+
+        <ol>
+          <li>
+            <p><strong>1. Multi-level baselines</strong></p>
+
+            <p>Letters may join through a finely inclined line</p>
+
+            <div style="margin-left: 40px;">
+              <img style=" width: 132px; height: 62px;"
+                   alt="slope baseline"
+                   src="images/yastabchiro.jpg">
+            </div>
+
+            <p>or two, square-ended lines</p>
+
+            <div style="margin-left: 40px;">
+              <img style=" width: 92px; height: 79px;"
+                   alt="two level baselin"
+                   src="images/yastami3o.jpg"><br>
+            </div>Multilevel baselines don't occur in all fonts. The above
+            examples use the Arabic Typesetting font. Compare those examples to
+            to more typical fonts:<br>
+
+            <p style="margin-left: 40px;"><img style=
+            "width: 110px; height: 93px;"
+                 alt="normal Font"
+                 src="images/yastabchiroNormal.jpg"></p>
+          </li>
+
+          <li>
+            <p><strong>2. Multi-context joining</strong></p>
+
+            <p>Rendering of letters depends not only on their place in the word
+            (initial, medial, final) but also on their neighboring letters,
+            i.e. the letter they join with. Each letter has a different
+            appearance in each combination.</p>
+
+            <figure>
+              <img style="width: 324px; height: 79px;"
+                      alt="Different initial shape of noon"
+                      src="images/differentInitialNoon.jpg">
+
+              <figcaption>Initial letter noon, showing many different
+              forms.</figcaption>
+            </figure>
+
+            <p>Fonts don't always comply with or respect this kind of
+            <span class="qterm">tuning</span>. To do so, fonts need many glyphs
+            in order to adapt to each context. In more modern typefaces some of
+            these connections are implemented by ligatures, but ligatures can't
+            capture or cover all joining behavior.</p>
+
+            <p>In the two left most words, the initial noon differs in that one
+            raises a kind of stroke. This property of raising a stroke is
+            common for a number of letters (beh, teh, noon, theh) which are
+            taller than their connected letters in order to be distinguished in
+            some contexts, such as<img style=
+            "width: 37px; height: 31px; align: middle;"
+                 alt="Beh with stroke before seen"
+                 src="images/bsl.jpg"> vs. <img style=
+                 "width: 43px; height: 39px; align: middle;"
+                 alt="Beh without stroke after seen"
+                 src="images/sbl.jpg"> , or to resolve ambiguity. See also the
+                 section about teeth letters below.</p>
+          </li>
+
+          <li>
+            <p><strong>3. Words as groups of letters<br></strong></p>
+
+            <p>A word shape is not (only) a "horizontal" connections of
+            letters, but of groups of letters (syntagmes??).</p>
+
+            <p>Example two words in some nice Naskh font.</p>
+
+            <table style="margin-left: 40px;">
+              <caption style="align: bottom;">
+                Groups of letters are colored blue or red
+              </caption>
+
+              <tbody>
+                <tr>
+                  <td style=" text-align: center; width: 40%;"><img style=
+                  "width: 76px; height: 46px;"
+                       alt="Aleph and two groups of letters to form a word"
+                       src="images/barmajaAmiri.jpg"></td>
+
+                  <td style="vertical-align: top;"><br></td>
+
+                  <td style="text-align: center;width:40%;"><img style=
+                  " width: 127px; height: 57px;"
+                       alt="two other group of letters"
+                       src="images/stimrarihimaArabicTypesetting.jpg"></td>
+                </tr>
+              </tbody>
+            </table>
+
+            <p>To compare with the same words in more usual font:</p>
+
+            <table style="margin-left: 40px;">
+              <caption style="align: bottom;">
+                Can't really say letter groups. Rather a "horizontal sequence
+                of letters of almost same width".
+              </caption>
+
+              <tbody>
+                <tr>
+                  <td style="text-align: center; width:40%;"><img style=
+                  " width: 98px; height: 43px;"
+                       alt="same word in more normal font"
+                       src="images/barmajaDefault.png"></td>
+
+                  <td style=" text-align: center; width: 40%;"><img style=
+                  " width: 144px; height: 46px;"
+                       alt="same word in default font"
+                       src="images/stimrarihimaDefault.jpg"></td>
+                </tr>
+              </tbody>
+            </table>
+
+            <p>Group combinations cannot be covered by general or usual
+            ligatures.</p>
+
+            <p><strong>4. Vertical</strong> <strong>joining</strong></p>
+
+            <p>Groups of letters may also join vertically (top down) instead of
+            right to left. And not all fonts permit this.</p>
+
+            <table style="margin-left: 40px;">
+              <tbody>
+                <tr>
+                  <td style=" text-align: center;"><img style=
+                  "width: 65px; height: 70px; align: middle;"
+                       alt="Vertical joining"
+                       src="images/vertivalJoin.jpg"></td>
+
+                  <td style=" text-align: center;">vs.</td>
+
+                  <td style=" text-align: center;"><img style=
+                  "width: 69px; height: 46px; align: middle;"
+                       alt="horizontal joing"
+                       src="images/horizontalJoin.jpg"></td>
+                </tr>
+
+                <tr>
+                  <td style="text-align: center;">Joining happens almost
+                  vertical</td>
+
+                  <td></td>
+
+                  <td style="text-align: center;">Joining happens
+                  horizontal</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <p>Once again, some fonts try standard ligatures, but this is not
+            ligature. This is rather (good) writing practice/style.</p>
+
+            <p>One should note that all this characteristics has not only an
+            aesthetic side, but also play a role in justification. It is at the
+            discretion of (hand writing) authors to chose the best kind of
+            joining to suit the desired line width. Should then be a general
+            rule on that. But to achieve such justification would require
+            sophisticated algorithms.</p>
+
+            <p><strong>5. The so called teeth letters.</strong></p>
+
+            <p>Letters having uniform medial shape, align in a kind of
+            teeth.</p>
+
+            <div style="margin-left: 40px;">
+              <img style=" width: 276px; height: 74px;"
+                   alt="Teeth letters"
+                   src="images/teeth.jpg">
+            </div>
+
+            <p>Even in the teeth context letter shape may vary. It's not the
+            same letters (in red) which raise the stroke in the two
+            figures.</p>
+          </li>
+        </ol>
+      </section>
+
+      <section id="h_fonts">
+        <h3><span style="font-weight: bold;">Fonts</span></h3>
+
+        <p>Arabic script counts 26 letters, and mostly 19 basic shapes. Since
+        letters change according to their position in the word, Arabic set of
+        glyph may range to more than one hundred shapes. If one count possible
+        ligatures, and different combination of joining forms (see above), the
+        number of glyph can increase further. Not sure that typeface design can
+        accommodate all needs, even though some present typefaces can run
+        hundred of shapes.</p>
+
+        <p>Early typefaces, some still in use today, were designed with some
+        facilities. Designer of those differs in their simplification
+        hypothesis. For example, one of the first approach is to use "type
+        writer style", that is a same glyph for different positions in a word.
+        This is the case for initial and medial shape for most of the letters
+        (example here). It is generally the browser default font for Arabic
+        script. A more unifying approach is the use of a single and detached
+        glyph for each letter without joining (todo example here). Other
+        approach were used resulting in more or less visually practical
+        fonts.</p>
+
+        <p>Nowadays, there is a large choice of fonts, and one can choose the
+        font that best suits to one's typographical desire. However, one may
+        also wishes to take into account some non typographical considerations
+        like: (TBD later on)</p>
+
+        <ul>
+          <li>Accessibility (readability and visibility) ...</li>
+
+          <li>The kind of device with small screen (for example, larger loop
+          and teeth height, small descenders etc...), although font actually
+          appear better on smartphones</li>
+
+          <li>Font style for titles and banners and alike (small number of
+          words), may differ from the style for content text (long text).</li>
+
+          <li>Shapes and proportions (the size issue) in mixed texts</li>
+
+          <li>Some fonts might give another opportunity for line justification
+          than the one based on word spacing (todo example MHMD).</li>
+
+          <li>etc...</li>
+        </ul>
+      </section>
+    </section>
   </section>
-  </section>
 
-
-
-
-
-
-
-  
-<section id="h_characters_and_words">
+  <section id="h_characters_and_words">
     <h2><a href="#h_characters_and_words">Characters and Words</a></h2>
-<section id="h_diacritics">
-    <h3><a href="#h_diacritics">Diacritics</a></h3>
-    <p>In Arabic script text it is unusual to use diacritics for  vowel information and for consonant lengthening.</p>
-    <section class="questions">
-      <p>Issues/questions:</p>
-      <ul>
-        <li>Some applications allow adjustment of the distance between 
-the diacritics and the base character. Is this a requirement for most 
-text systems?</li>
-        <li>What about adjustment to the horizontal position of the diacritic?</li>
-        <li>Should it be possible to influence whether a font places the
- kasra below the base character or immediately below the shadda, when 
-combined with the latter?</li>
-      </ul>
-    </section>
-  </section>
 
- <section>
-    <p>Topic Keywords:</p>
-    <ul>
-      <li>
-        <strong>Arrangement and Joining Behaviour:</strong> Application of letter-spacing and its
-        relation with elongation and cursive characterists. Description of different cases of
-        dealing with joining and text alignment, such as behavior of ZWNJ and ZWJ, glyph
-        overlapping, joining and text-shaping behavior across inline markup denoting style or font
-        selection, single-glyph styling without breaking joining, and letter-spacing. Also, see
-        topics under <a href="#h_lines_and_paragraphs">Lines and Paragraphs</a> section.
-      </li>
-      <li><strong>Spacing:</strong> Use of space as word boundary and exceptions ("و" conjunction
-        in Arabic orthography, "ل" before a non-Arabic script noun). Misuse of space in place of ZWNJ
-      in some Arabic script languages.</li>
-      <li><strong>Numbers and counting:</strong> An overview of different numbering solutions
-        (digits, Abjad, …) and provide resources and guidelines on how to choose the right set of
-      numerals based on the language.</li>
-      <li><strong>Font and Typographical considerations:</strong> Common typographical styles and
-        their visual identity according to historical and contemporary usages. Font size
-        considerations for mixed-script text. Ligatures and their categories (optional vs.
-        mandatory). Use or misuse of some generic font-styles such as italic and oblique with Arabic
-      script.</li>
-    </ul>
-  </section>
-  </section>
+    <section id="h_diacritics">
+      <h3><a href="#h_diacritics">Diacritics</a></h3>
 
+      <p>In Arabic script text it is unusual to use diacritics for vowel
+      information and for consonant lengthening.</p>
 
-
-
-
-
-
-
-
-
-
-
-  
-
-
-
-  
-
-  
-<section id="h_lines_and_paragraphs">
-    <h2><a href="#h_lines_and_paragraphs">Lines and Paragraphs</a></h2>
-
-  <section id="h_line_breaking">
-    <h3><a href="#h_line_breaking">Line breaking</a></h3>
-    <p>When Arabic text doesn't fit within the available line width, the text is wrapped to the next line between words. </p>
-    <p>In bidirectional text, if a line break occurs between a sequence 
-of words that are progressing in a left-to-right direction the first 
-line will be filled with LTR words that come at the start of the phrase 
-in the order spoken (ie. not the visual order when laid out in a single 
-line). This is because it is never correct to read lines from bottom to 
-top. A similar rearrangement is required when a sequence of 
-right-to-left words is split at the end of a line in an overall LTR 
-context.</p>
-    <section class="questions">
-      <p>Issues/questions:</p>
-      <ul>
-        <li>In Urdu words are not necessarily bounded by spaces. What method is used for determining appropriate break points in this case?</li>
-        <li>What other characters besides SPACE constitute break points for automatic line wrapping?</li>
-        <li>What are the rules for hyphenation in Arabic script text?</li>
-        <li>The CSS Text spec <a href="https://drafts.csswg.org/css-text-3/#example-953e914f">says</a>
- "When shaping scripts such as Arabic are allowed to break within words 
-due to hyphenation, the characters must still be shaped as if the word 
-were not broken." The example shows Uighur text with a hyphen at the end
- of a line and with shaped characters at line end and start. Is this 
-normal in Arabic and Persian text also?</li>
-        <li>In some styles of CJK typesetting, English words are allowed
- to break between any two letters, rather than only at spaces or 
-hyphenation points. Are the rules different form Arabic script text?</li>
-        <li>The CSS spec <a href="https://drafts.csswg.org/css-text-3/#example-b3227dab">says</a>
- "When shaping scripts such as Arabic are allowed to break within words 
-due to break-all, the characters must still be shaped as if the word 
-were not broken." Is this true?</li>
-        <li>The CSS <a href="https://drafts.csswg.org/css-text-3/#hanging-punctuation-property">hanging-punctuation</a>
- property allows the arabic comma and arabic full stop to hang in the 
-margin, rather than wrapping them to the next line. Is this appropriate?</li>
-      </ul>
-    </section>
-  </section>
-
-  <section id="h_justification">
-    <h2><a href="#h_justification">Justification</a></h2>
-
-    <div class="note">
-      <h3>Notes, Links, …</h3>
-      <ul>
-        <li>Drop “elongation” from title of this section. It’s one of the mechanisms used for justification.</li>
-        <li>Make sure “elongation,” “kashida,” and “tatweel,” have correct definitions in our glossary.</li>
-        <li><a href="http://www.w3.org/2016/06/28-alreq-minutes.html">Discussion at ALReq meeting on 28 June, 2016</a></li>
-        <li><a href="http://quod.lib.umich.edu/j/jep/3336451.0013.105?rgn=main;view=fulltext">Justify Just or Just Justify</a></li>
-        <li><a href="http://www.tug.org/TUGboat/tb27-2/tb87benatia.pdf">Arabic text justification</a></li>
-        <li>Thomas Milo’s “Arabic script and typography: A brief historical view”</li>
-        <li><a href="http://www.decotype.com/pdfs/Tasmeem_Manual.pdf">Tasmeem Manual</a></li>
-        <li><a href="https://www.microsoft.com/middleeast/msdn/JustifyingText-CSS.aspx">Justifying Text using Cascading Style Sheets (CSS) in Internet Explorer 5.5</a></li>
-        <li><strong>TODO:</strong> Improve the images.</li>
-      </ul>
-
-      <hr />
-
-      <p>There are a number of different ways to produce justified text
-        in Arabic. In some cases several of these methods may be combined. In
-        other cases, certain methods are disallowed.</p>
-      <p>Typical methods include:</p>
-      <ul>
-        <li>Expansion or contraction of inter-word spaces.</li>
-        <li>Expansion or contraction of intra-word spaces, ie. the space
-          following a character in the middle of a word that doesn't join with
-          the character that follows it.</li>
-        <li>Use of wider glyph forms for certain characters.</li>
-        <li>Stretching of the joins between characters, known as 'kashida'.</li>
-        <li>Use of ligated forms, to reduce space taken by characters on a line.</li>
-      </ul>
       <section class="questions">
         <p>Issues/questions:</p>
+
         <ul>
-          <li>What are the rules for elongation of inter-character baselines, and how do they differ from one font style to another?</li>
-          <li>When is it appropriate to use which method? </li>
-          <li>Is the tatweel character useful?</li>
-          <li>What should happen if an application uses a ruq'ah font as
-            a fallback, which cannot allow for word elongation? Does the
-            application need to automatically know that it should not stretch words
-            when using this font style?</li>
-          <li>How does an application or person decide which methods to use, and where, to justify text?</li>
-          <li>The CSS Text spec says: that, apart from elongation,
+          <li>Some applications allow adjustment of the distance between the
+          diacritics and the base character. Is this a requirement for most
+          text systems?</li>
+
+          <li>What about adjustment to the horizontal position of the
+          diacritic?</li>
+
+          <li>Should it be possible to influence whether a font places the
+          kasra below the base character or immediately below the shadda, when
+          combined with the latter?</li>
+        </ul>
+      </section>
+    </section>
+
+    <section>
+      <p>Topic Keywords:</p>
+
+      <ul>
+        <li><strong>Arrangement and Joining Behaviour:</strong> Application of
+        letter-spacing and its relation with elongation and cursive
+        characterists. Description of different cases of dealing with joining
+        and text alignment, such as behavior of ZWNJ and ZWJ, glyph
+        overlapping, joining and text-shaping behavior across inline markup
+        denoting style or font selection, single-glyph styling without breaking
+        joining, and letter-spacing. Also, see topics under <a href=
+        "#h_lines_and_paragraphs">Lines and Paragraphs</a> section.</li>
+
+        <li><strong>Spacing:</strong> Use of space as word boundary and
+        exceptions ("و" conjunction in Arabic orthography, "ل" before a
+        non-Arabic script noun). Misuse of space in place of ZWNJ in some
+        Arabic script languages.</li>
+
+        <li><strong>Numbers and counting:</strong> An overview of different
+        numbering solutions (digits, Abjad, …) and provide resources and
+        guidelines on how to choose the right set of numerals based on the
+        language.</li>
+
+        <li><strong>Font and Typographical considerations:</strong> Common
+        typographical styles and their visual identity according to historical
+        and contemporary usages. Font size considerations for mixed-script
+        text. Ligatures and their categories (optional vs. mandatory). Use or
+        misuse of some generic font-styles such as italic and oblique with
+        Arabic script.</li>
+      </ul>
+    </section>
+  </section>
+
+  <section id="h_lines_and_paragraphs">
+    <h2><a href="#h_lines_and_paragraphs">Lines and Paragraphs</a></h2>
+
+    <section id="h_line_breaking">
+      <h3><a href="#h_line_breaking">Line breaking</a></h3>
+
+      <p>When Arabic text doesn't fit within the available line width, the text
+      is wrapped to the next line between words.</p>
+
+      <p>In bidirectional text, if a line break occurs between a sequence of
+      words that are progressing in a left-to-right direction the first line
+      will be filled with LTR words that come at the start of the phrase in the
+      order spoken (ie. not the visual order when laid out in a single line).
+      This is because it is never correct to read lines from bottom to top. A
+      similar rearrangement is required when a sequence of right-to-left words
+      is split at the end of a line in an overall LTR context.</p>
+
+      <section class="questions">
+        <p>Issues/questions:</p>
+
+        <ul>
+          <li>In Urdu words are not necessarily bounded by spaces. What method
+          is used for determining appropriate break points in this case?</li>
+
+          <li>What other characters besides SPACE constitute break points for
+          automatic line wrapping?</li>
+
+          <li>What are the rules for hyphenation in Arabic script text?</li>
+
+          <li>The CSS Text spec <a href=
+          "https://drafts.csswg.org/css-text-3/#example-953e914f">says</a>
+          "When shaping scripts such as Arabic are allowed to break within
+          words due to hyphenation, the characters must still be shaped as if
+          the word were not broken." The example shows Uighur text with a
+          hyphen at the end of a line and with shaped characters at line end
+          and start. Is this normal in Arabic and Persian text also?</li>
+
+          <li>In some styles of CJK typesetting, English words are allowed to
+          break between any two letters, rather than only at spaces or
+          hyphenation points. Are the rules different form Arabic script
+          text?</li>
+
+          <li>The CSS spec <a href=
+          "https://drafts.csswg.org/css-text-3/#example-b3227dab">says</a>
+          "When shaping scripts such as Arabic are allowed to break within
+          words due to break-all, the characters must still be shaped as if the
+          word were not broken." Is this true?</li>
+
+          <li>The CSS <a href=
+          "https://drafts.csswg.org/css-text-3/#hanging-punctuation-property">hanging-punctuation</a>
+          property allows the arabic comma and arabic full stop to hang in the
+          margin, rather than wrapping them to the next line. Is this
+          appropriate?</li>
+        </ul>
+      </section>
+    </section>
+
+    <section id="h_justification">
+      <h2><a href="#h_justification">Justification</a></h2>
+
+      <div class="note">
+        <h3>Notes, Links, …</h3>
+
+        <ul>
+          <li>Drop “elongation” from title of this section. It’s one of the
+          mechanisms used for justification.</li>
+
+          <li>Make sure “elongation,” “kashida,” and “tatweel,” have correct
+          definitions in our glossary.</li>
+
+          <li><a href=
+          "http://www.w3.org/2016/06/28-alreq-minutes.html">Discussion at ALReq
+          meeting on 28 June, 2016</a></li>
+
+          <li><a href=
+          "http://quod.lib.umich.edu/j/jep/3336451.0013.105?rgn=main;view=fulltext">
+          Justify Just or Just Justify</a></li>
+
+          <li><a href=
+          "http://www.tug.org/TUGboat/tb27-2/tb87benatia.pdf">Arabic text
+          justification</a></li>
+
+          <li>Thomas Milo’s “Arabic script and typography: A brief historical
+          view”</li>
+
+          <li><a href="http://www.decotype.com/pdfs/Tasmeem_Manual.pdf">Tasmeem
+          Manual</a></li>
+
+          <li><a href=
+          "https://www.microsoft.com/middleeast/msdn/JustifyingText-CSS.aspx">Justifying
+          Text using Cascading Style Sheets (CSS) in Internet Explorer
+          5.5</a></li>
+
+          <li><strong>TODO:</strong> Improve the images.</li>
+        </ul>
+        <hr>
+
+        <p>There are a number of different ways to produce justified text in
+        Arabic. In some cases several of these methods may be combined. In
+        other cases, certain methods are disallowed.</p>
+
+        <p>Typical methods include:</p>
+
+        <ul>
+          <li>Expansion or contraction of inter-word spaces.</li>
+
+          <li>Expansion or contraction of intra-word spaces, ie. the space
+          following a character in the middle of a word that doesn't join with
+          the character that follows it.</li>
+
+          <li>Use of wider glyph forms for certain characters.</li>
+
+          <li>Stretching of the joins between characters, known as
+          'kashida'.</li>
+
+          <li>Use of ligated forms, to reduce space taken by characters on a
+          line.</li>
+        </ul>
+
+        <section class="questions">
+          <p>Issues/questions:</p>
+
+          <ul>
+            <li>What are the rules for elongation of inter-character baselines,
+            and how do they differ from one font style to another?</li>
+
+            <li>When is it appropriate to use which method?</li>
+
+            <li>Is the tatweel character useful?</li>
+
+            <li>What should happen if an application uses a ruq'ah font as a
+            fallback, which cannot allow for word elongation? Does the
+            application need to automatically know that it should not stretch
+            words when using this font style?</li>
+
+            <li>How does an application or person decide which methods to use,
+            and where, to justify text?</li>
+
+            <li>The CSS Text spec says: that, apart from elongation,
             applications "must assume that no justification opportunity exists
             between any pair of typographic letter units in cursive script
             (regardless of whether they join). " Is this correct? InDesign, for
-            example, allows alterations of gaps in the middle of a word where one
-            character doesn't join with the following character.</li>
-          <li>Should the CSS <a href="https://drafts.csswg.org/css-text-3/#cursive-tracking">letter-spacing property</a> have any effect on Arabic script text?</li>
-        </ul>
+            example, allows alterations of gaps in the middle of a word where
+            one character doesn't join with the following character.</li>
+
+            <li>Should the CSS <a href=
+            "https://drafts.csswg.org/css-text-3/#cursive-tracking">letter-spacing
+            property</a> have any effect on Arabic script text?</li>
+          </ul>
+        </section>
+      </div>
+
+      <p>Of the four basic justification methods (flush left, flush right,
+      justified, and centered), justified is the most challenging, as it
+      requires changing the widths of the lines to a pre-defined measure.
+      <span class="qterm">Measure</span> refers to the width of a column of
+      text. In a justified paragraph the width of all the lines should be the
+      same as the paragraph’s measure (except, of course, the list line).</p>
+
+      <p>In Arabic there are six mechanisms for changing the width of a line of
+      text. Each one has its limitations and considerations on when and how it
+      can be applied. Furthermore, different typographers and calligraphers
+      have divergent preferences for these mechanisms.</p>
+
+      <p>An important factor in the application of these mechanisms is they
+      success in creating an even <span class="qterm">color</span>. The color
+      of the text refers to the amount of ink/blackness used to print or show a
+      block of text. Color describes the density of the text against its
+      background. Poorly justifying paragraphs can create uneven distribution
+      of color.</p>
+
+      <p>These mechanisms are not exclusive. Quite the contrary, they are
+      commonly used simultaneously to produce better justified paragraphs.
+      Combination of these mechanisms is discussed in <a href=
+      "#h_combination_of_the_mechanisms">Combination of the Mechanisms</a>.</p>
+
+      <section id="h_adjusting_inter_word_spaces">
+        <h2>Adjusting Inter-Word Spaces</h2>
+
+        <p>This is the same mechanism widely used when justifying Latin
+        scripts, where the width of the spaces between the words can be
+        increased or decreased to change the width of the line.</p>
+
+        <figure>
+          <img src="images/adjusting-inter-word-spaces.svg"
+                  alt=
+                  "Aligning lines by increasing and decreasing spaces between the words.">
+
+          <figcaption>Aligning lines by increasing and decreasing spaces
+          between the words.</figcaption>
+        </figure>
+
+        <p>A minimum width is defined for how much the space can be shrunk,
+        because putting the words too close to each other creates aesthetic and
+        legibility problems.</p>
+
+        <p>Stretching the space too wide is also undesirable, but is utilized
+        as a last resort when it is not possible to use other solutions to make
+        fully justified paragraphs. In some applications a maximum width for
+        the inter-word space is defined as a soft limit (compared to minimum
+        width which is a hard limit). Reaching the maximum width makes the
+        software to try to use other solutions for justification. If no other
+        solution could yield the required result, the software would fall back
+        to inter-word spacing and stretch the space past the maximum width.</p>
+
+        <p>Depending solely on this mechanism for aligning lines in a justified
+        paragraph can lead to unpleasant results, such as rivers (multiple
+        stretched spaces appearing vertically close to each other and forming a
+        white gap inside the paragraph) and uneven distribution of color in the
+        paragraph. Hence, typographers generally use other mechanisms as well
+        to minimize the effect of adjusting inter-word spaces.</p>
       </section>
-    </div>
-    <p>Of the four basic justification methods (flush left, flush right, justified, and centered), justified is the most challenging, as it requires changing the widths of the lines to a pre-defined measure. <span class="qterm">Measure</span> refers to the width of a column of text. In a justified paragraph the width of all the lines should be the same as the paragraph’s measure (except, of course, the list line).</p>
-    <p>In Arabic there are six mechanisms for changing the width of a line of text. Each one has its limitations and considerations on when and how it can be applied. Furthermore, different typographers and calligraphers have divergent preferences for these mechanisms.</p>
-    <p>An important factor in the application of these mechanisms is they success in creating an even <span class="qterm">color</span>. The color of the text refers to the amount of ink/blackness used to print or show a block of text. Color describes the density of the text against its background. Poorly justifying paragraphs can create uneven distribution of color.</p>
-    <p>These mechanisms are not exclusive. Quite the contrary, they are commonly used simultaneously to produce better justified paragraphs. Combination of these mechanisms is discussed in <a href="#h_combination_of_the_mechanisms">Combination of the Mechanisms</a>.</p>
 
-    <section id="h_adjusting_inter_word_spaces">
-      <h2>Adjusting Inter-Word Spaces</h2>
-      <p>This is the same mechanism widely used when justifying Latin scripts, where the width of the spaces between the words can be increased or decreased to change the width of the line.</p>
-      <figure>
-        <img src="images/adjusting-inter-word-spaces.svg" alt="Aligning lines by increasing and decreasing spaces between the words." width="90%" />
-        <figcaption>Aligning lines by increasing and decreasing spaces between the words.</figcaption>
-      </figure>
-      <p>A minimum width is defined for how much the space can be shrunk, because putting the words too close to each other creates aesthetic and legibility problems.</p>
-      <p>Stretching the space too wide is also undesirable, but is utilized as a last resort when it is not possible to use other solutions to make fully justified paragraphs. In some applications a maximum width for the inter-word space is defined as a soft limit (compared to minimum width which is a hard limit). Reaching the maximum width makes the software to try to use other solutions for justification. If no other solution could yield the required result, the software would fall back to inter-word spacing and stretch the space past the maximum width.</p>
-      <p>Depending solely on this mechanism for aligning lines in a justified paragraph can lead to unpleasant results, such as rivers (multiple stretched spaces appearing vertically close to each other and forming a white gap inside the paragraph) and uneven distribution of color in the paragraph. Hence, typographers generally use other mechanisms as well to minimize the effect of adjusting inter-word spaces.</p>
-    </section>
+      <section id="h_adjusting_intra_word_spaces">
+        <h2>Adjusting Intra-Word Spaces</h2>
 
-    <section id="h_adjusting_intra_word_spaces">
-      <h2>Adjusting Intra-Word Spaces</h2>
-      <p>This solution alters the space between letters of each word to change the width of the text. Like adjusting inter-word spaces, this is used for Latin scripts as well, but using it for Arabic script involves considerations specific to Arabic. As noted in <a href="#h_joining_and_spacing">Joining and Intra-Word Spaces</a>, the principal consideration is that gaps between characters only exist for those letters that join only to the right, such as <span class="lettername">dal</span> and <span class="lettername">reh</span> . Adjustment of intra-word space is not relevant where one letter is joined to its neighbors.</p>
-      <figure>
-        <img src="images/adjusting-intra-word-spaces.png" alt="Altering intra-word spaces between unjoined letters." />
-        <figcaption>Altering intra-word spaces between unjoined letters.</figcaption>
-      </figure>
-      <p>Depending on the writing style and the typeface in use, different amounts of alteration to the intra-word space is acceptable for Arabic. Some writing styles allow more liberal adjustments to the closeness of the letter groups, while others can only accept small adjustments in this regard. In any case, much smaller adjustments can be used for intra-word spacing in comparison for inter-word spacing, which naturally is wider and tolerate bigger adjustments.</p>
-    </section>
+        <p>This solution alters the space between letters of each word to
+        change the width of the text. Like adjusting inter-word spaces, this is
+        used for Latin scripts as well, but using it for Arabic script involves
+        considerations specific to Arabic. As noted in <a href=
+        "#h_joining_and_spacing">Joining and Intra-Word Spaces</a>, the
+        principal consideration is that gaps between characters only exist for
+        those letters that join only to the right, such as <span class=
+        "lettername">dal</span> and <span class="lettername">reh</span> .
+        Adjustment of intra-word space is not relevant where one letter is
+        joined to its neighbors.</p>
 
-    <section>
-      <h2>Alternative Shapes</h2>
-      <p>In addition to the four joining forms (isolated, initial, medial, and final), each Arabic letter can come with different shapes while preserving its joining form. For instance, a typeface or writing style can offer two or more shapes for the final form of a single letter.</p>
-      <p>These variant shapes usually have variant widths and hence can be used to adjust the width of the line.</p>
-      <figure>
-        <img src="images/alternative-letter-shapes.png" alt="Alternative shapes for changing the width of the text." />
-        <figcaption>Alternative shapes for changing the width of the text.</figcaption>
-      </figure>
-      <p>An advantage of using alternative letter shapes when justifying paragraphs is that it does not involve modifying default properties of the typeface (width of space or other characters). Instead, it is using shapes that are part of the typeface and are in harmony with other shapes in the lines.</p>
-      <p>But excessive use of alternative shapes, such as using multiple very wide alternatives close to each other, can create unnatural results.</p>
-      <p>It is not possible to justify paragraphs using only alternative letter shapes, because these shapes have predefined widths. For example, if a line should get 25 points wider, it is impossible to achieve that by using alternative letter shapes that are, say, 10 or 20 or 30 points wider than the default shapes. But these shapes can make the lines closer to measure, thus reducing the usage of other mechanisms.</p>
-    </section>
+        <figure>
+          <img src="images/adjusting-intra-word-spaces.png"
+                  alt="Altering intra-word spaces between unjoined letters.">
 
-    <section>
-      <h2>Ligatures</h2>
-      <p>Some Arabic fonts, following the writing styles that use special shapes when joining certain letters, provide a rich number of ligatures. These ligatures can be used in paragraph justification, since they usually reduce the widths of the words.</p>
-      <figure>
-        <img src="images/different-ligatures.png" alt="Various ligatures reducing the widths of the words" />
-        <figcaption>Various ligatures reducing the widths of the words</figcaption>
-      </figure>
-      <p>But existence of the ligatures in a font does not mean that they can be used freely. A font may provide some of its ligatures for creating an artistic style, which would be unsuitable for texts requiring optimum legibility.</p>
-      <p>For that reason, the user should be able to select which sets of ligatures can be used for justification. Fonts can offer predefined sets of ligatures to simplify this process.</p>
-    </section>
+          <figcaption>Altering intra-word spaces between unjoined
+          letters.</figcaption>
+        </figure>
 
-    <section>
-      <h2>Kashida</h2>
-    </section>
+        <p>Depending on the writing style and the typeface in use, different
+        amounts of alteration to the intra-word space is acceptable for Arabic.
+        Some writing styles allow more liberal adjustments to the closeness of
+        the letter groups, while others can only accept small adjustments in
+        this regard. In any case, much smaller adjustments can be used for
+        intra-word spacing in comparison for inter-word spacing, which
+        naturally is wider and tolerate bigger adjustments.</p>
+      </section>
 
-    <section>
-      <h2>Tatweel</h2>
-    </section>
+      <section>
+        <h2>Alternative Shapes</h2>
 
-    <section id="h_combination_of_the_mechanisms">
-      <h2>Combination of the Mechanisms</h2>
+        <p>In addition to the four joining forms (isolated, initial, medial,
+        and final), each Arabic letter can come with different shapes while
+        preserving its joining form. For instance, a typeface or writing style
+        can offer two or more shapes for the final form of a single letter.</p>
+
+        <p>These variant shapes usually have variant widths and hence can be
+        used to adjust the width of the line.</p>
+
+        <figure>
+          <img src="images/alternative-letter-shapes.png"
+                  alt="Alternative shapes for changing the width of the text.">
+
+          <figcaption>Alternative shapes for changing the width of the
+          text.</figcaption>
+        </figure>
+
+        <p>An advantage of using alternative letter shapes when justifying
+        paragraphs is that it does not involve modifying default properties of
+        the typeface (width of space or other characters). Instead, it is using
+        shapes that are part of the typeface and are in harmony with other
+        shapes in the lines.</p>
+
+        <p>But excessive use of alternative shapes, such as using multiple very
+        wide alternatives close to each other, can create unnatural
+        results.</p>
+
+        <p>It is not possible to justify paragraphs using only alternative
+        letter shapes, because these shapes have predefined widths. For
+        example, if a line should get 25 points wider, it is impossible to
+        achieve that by using alternative letter shapes that are, say, 10 or 20
+        or 30 points wider than the default shapes. But these shapes can make
+        the lines closer to measure, thus reducing the usage of other
+        mechanisms.</p>
+      </section>
+
+      <section>
+        <h2>Ligatures</h2>
+
+        <p>Some Arabic fonts, following the writing styles that use special
+        shapes when joining certain letters, provide a rich number of
+        ligatures. These ligatures can be used in paragraph justification,
+        since they usually reduce the widths of the words.</p>
+
+        <figure>
+          <img src="images/different-ligatures.png"
+                  alt="Various ligatures reducing the widths of the words">
+
+          <figcaption>Various ligatures reducing the widths of the
+          words</figcaption>
+        </figure>
+
+        <p>But existence of the ligatures in a font does not mean that they can
+        be used freely. A font may provide some of its ligatures for creating
+        an artistic style, which would be unsuitable for texts requiring
+        optimum legibility.</p>
+
+        <p>For that reason, the user should be able to select which sets of
+        ligatures can be used for justification. Fonts can offer predefined
+        sets of ligatures to simplify this process.</p>
+      </section>
+
+      <section>
+        <h2>Kashida</h2>
+      </section>
+
+      <section>
+        <h2>Tatweel</h2>
+      </section>
+
+      <section id="h_combination_of_the_mechanisms">
+        <h2>Combination of the Mechanisms</h2>
+      </section>
     </section>
-  </section>
 
     <section id="h_para_line_alignment">
-      <h3><a href="#h_para_line_alignment">Paragraph and line alignment</a></h3>
-      <p>Lines of Arabic script text are normally right aligned within the page.</p>
+      <h3><a href="#h_para_line_alignment">Paragraph and line
+      alignment</a></h3>
+
+      <p>Lines of Arabic script text are normally right aligned within the
+      page.</p>
+
       <section class="questions">
         <p>Issues/questions:</p>
+
         <ul>
-          <li>When a list on an Arabic page contains an item that is 
-completely composed of LTR text, should the list item be right- or 
-left-aligned on the page?</li>
-          <li>If a list item is left-sligned on an Arabic page because 
-it contains only LTR text, should the list item counter be to the right 
-or to the left?</li>
+          <li>When a list on an Arabic page contains an item that is completely
+          composed of LTR text, should the list item be right- or left-aligned
+          on the page?</li>
+
+          <li>If a list item is left-sligned on an Arabic page because it
+          contains only LTR text, should the list item counter be to the right
+          or to the left?</li>
         </ul>
       </section>
     </section>
 
     <p>Topic Keywords:</p>
+
     <ul>
-      <li><strong>Line composition rules:</strong> Characters which can not appear in start and end
-      of the line. Mid-word and mid-sentence line breaking behaviour.</li>
-      <li><strong>Punctuations:</strong> Use and positioning of punctuation marks in the sentence.
-      Use of paired punctuation marks.</li>
+      <li><strong>Line composition rules:</strong> Characters which can not
+      appear in start and end of the line. Mid-word and mid-sentence line
+      breaking behaviour.</li>
+
+      <li><strong>Punctuations:</strong> Use and positioning of punctuation
+      marks in the sentence. Use of paired punctuation marks.</li>
+
       <li><strong>Mixed script text:</strong></li>
-      <li><strong>Directionality and bidi:</strong> Special considerations for mixed script
-      text.</li>
-      <li><strong>Paragraph adjustment and alignment:</strong> Paragraph spacing and indentation
-      rules.</li>
+
+      <li><strong>Directionality and bidi:</strong> Special considerations for
+      mixed script text.</li>
+
+      <li><strong>Paragraph adjustment and alignment:</strong> Paragraph
+      spacing and indentation rules.</li>
+
       <li><strong>Tab setting:</strong></li>
-      <li>
-        <strong>Justification and Elongation/Tatweel/Kashida:</strong> Common <a href="#def_justify" class="termref">justification</a> considerations. Patterns of application of
-        tatweel; e.g. only between or after certain characters or grapheme clusters, number of
-        tatweels allowed per line or word, current length of a word and location of it prior to
-        tatweel, flexibility of patterns according to font-families and typographic styles.
-        Possible relationship between tatweel, letter-spacing and decomposition of ligatures.
-      </li>
-      <li><strong>Hyphenation:</strong> Uses of hyphenation for breaking words across lines; a
-      functioning of Arabic script or specific languages using the writing system?</li>
+
+      <li><strong>Justification and Elongation/Tatweel/Kashida:</strong> Common
+      <a href="#def_justify"
+         class="termref">justification</a> considerations. Patterns of
+         application of tatweel; e.g. only between or after certain characters
+         or grapheme clusters, number of tatweels allowed per line or word,
+         current length of a word and location of it prior to tatweel,
+         flexibility of patterns according to font-families and typographic
+         styles. Possible relationship between tatweel, letter-spacing and
+         decomposition of ligatures.</li>
+
+      <li><strong>Hyphenation:</strong> Uses of hyphenation for breaking words
+      across lines; a functioning of Arabic script or specific languages using
+      the writing system?</li>
+
       <li><strong>Word/Sentence boundaries:</strong></li>
-      <li><strong>Special cases:</strong> Poetry, bullet lists, math, vertical text, drop-letters,
-      etc.</li>
+
+      <li><strong>Special cases:</strong> Poetry, bullet lists, math, vertical
+      text, drop-letters, etc.</li>
     </ul>
   </section>
 
-
-  
-  
-  
-<section id="h_pages">
+  <section id="h_pages">
     <h2><a href="#h_pages">Pages</a></h2>
+
     <p>Topic Keywords:</p>
+
     <ul>
       <li><strong>Basic common templates:</strong></li>
+
       <li><strong>Page elements:</strong></li>
-      <li><strong>Page-level directionality:</strong> Directionality of page elements.
-      Bidirectional behaviour in mixed script texts on the page.</li>
+
+      <li><strong>Page-level directionality:</strong> Directionality of page
+      elements. Bidirectional behaviour in mixed script texts on the page.</li>
+
       <li><strong>Arrangement of elements on the page:</strong></li>
+
       <li><strong>Text columns:</strong></li>
+
       <li><strong>Header:</strong></li>
+
       <li><strong>Footers:</strong> Footnotes and numbering schemes.</li>
+
       <li><strong>Illustrations:</strong></li>
-      <li><strong>Tables:</strong> Directional behvaiour of tables. Mixed script text in
-      tables.</li>
-      <li><strong>Page numbers:</strong> Positions of page numbers on the page. Mentioning
-      contemporary and traditional use of Abjad page numbering.</li>
+
+      <li><strong>Tables:</strong> Directional behvaiour of tables. Mixed
+      script text in tables.</li>
+
+      <li><strong>Page numbers:</strong> Positions of page numbers on the page.
+      Mentioning contemporary and traditional use of Abjad page numbering.</li>
+
       <li><strong>Page margins:</strong></li>
+
       <li><strong>Positioning and arrangement of content:</strong></li>
+
       <li><strong>Pagination rules:</strong></li>
+
       <li><strong>Specimens and examples:</strong></li>
     </ul>
   </section>
 
-
-  
-<section id="h_document">
+  <section id="h_document">
     <h2>Document</h2>
+
     <p>Topic Keywords:</p>
+
     <ul>
       <li><strong>Distinguished requirements:</strong> book/ebook/page</li>
+
       <li><strong>Inter-page spacing:</strong></li>
-      <li><strong>First and last pages:</strong> Common practices for first and last pages.</li>
+
+      <li><strong>First and last pages:</strong> Common practices for first and
+      last pages.</li>
+
       <li><strong>Table of Contents and lists:</strong></li>
+
       <li><strong>Indexes:</strong> Sorting of names.</li>
-      <li><strong>Appendices:</strong> Bibliographies, glossaries, endnotes, etc.</li>
+
+      <li><strong>Appendices:</strong> Bibliographies, glossaries, endnotes,
+      etc.</li>
     </ul>
   </section>
 
+  <section class="appendix"
+           id="characters-tables">
+    <h2>Characters</h2>
 
-	
-<section class="appendix" id="characters-tables">
-		<h2>Characters</h2>
-		<p>The following tables list Unicode characters used for Arabic script, excluding ASCII. Each table has two columns named <span class="qterm">Ar</span> and <span class="qterm">Fa</span>
- which denote which characters are used for Arabic or Persian languages,
- respectively. A black circle (●) under each of these two columns means 
-that a character is used for that language. A white circle (○) denotes a
- character that is auxiliary for that language. An X mark (✕) means the 
-character is not used for that langauge.</p>
-		<h3>Alphabetical characters</h3>
-		<table class="characters">
-			<thead>
-				<tr>
-					<th class="charColumn">Character</th>
-					<th class="ucsColumn">UCS</th>
-					<th class="charnameColumn">Name</th>
-					<th class="languageColumn">Ar</th>
-					<th class="languageColumn">Fa</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr id="def_U+0621">
-					<td class="rtlTermCell" lang="ar">ء</td>
-					<td class="uname">U+0621</td>
-					<td class="uname">ARABIC LETTER HAMZA</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0622">
-					<td class="rtlTermCell" lang="ar">آ</td>
-					<td class="uname">U+0622</td>
-					<td class="uname">ARABIC LETTER ALEF WITH MADDA ABOVE</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0623">
-					<td class="rtlTermCell" lang="ar">أ</td>
-					<td class="uname">U+0623</td>
-					<td class="uname">ARABIC LETTER ALEF WITH HAMZA ABOVE</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0624">
-					<td class="rtlTermCell" lang="ar">ؤ</td>
-					<td class="uname">U+0624</td>
-					<td class="uname">ARABIC LETTER WAW WITH HAMZA ABOVE</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0625">
-					<td class="rtlTermCell" lang="ar">إ</td>
-					<td class="uname">U+0625</td>
-					<td class="uname">ARABIC LETTER ALEF WITH HAMZA BELOW</td>
-					<td class="langMark">●</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+0626">
-					<td class="rtlTermCell" lang="ar">ئ</td>
-					<td class="uname">U+0626</td>
-					<td class="uname">ARABIC LETTER YEH WITH HAMZA ABOVE</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0627">
-					<td class="rtlTermCell" lang="ar">ا</td>
-					<td class="uname">U+0627</td>
-					<td class="uname">ARABIC LETTER ALEF</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0628">
-					<td class="rtlTermCell" lang="ar">ب</td>
-					<td class="uname">U+0628</td>
-					<td class="uname">ARABIC LETTER BEH</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0629">
-					<td class="rtlTermCell" lang="ar">ة</td>
-					<td class="uname">U+0629</td>
-					<td class="uname">ARABIC LETTER TEH MARBUTA</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+062A">
-					<td class="rtlTermCell" lang="ar">ت</td>
-					<td class="uname">U+062A</td>
-					<td class="uname">ARABIC LETTER TEH</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+062B">
-					<td class="rtlTermCell" lang="ar">ث</td>
-					<td class="uname">U+062B</td>
-					<td class="uname">ARABIC LETTER THEH</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+062C">
-					<td class="rtlTermCell" lang="ar">ج</td>
-					<td class="uname">U+062C</td>
-					<td class="uname">ARABIC LETTER JEEM</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+062D">
-					<td class="rtlTermCell" lang="ar">ح</td>
-					<td class="uname">U+062D</td>
-					<td class="uname">ARABIC LETTER HAH</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+062E">
-					<td class="rtlTermCell" lang="ar">خ</td>
-					<td class="uname">U+062E</td>
-					<td class="uname">ARABIC LETTER KHAH</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+062F">
-					<td class="rtlTermCell" lang="ar">د</td>
-					<td class="uname">U+062F</td>
-					<td class="uname">ARABIC LETTER DAL</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0630">
-					<td class="rtlTermCell" lang="ar">ذ</td>
-					<td class="uname">U+0630</td>
-					<td class="uname">ARABIC LETTER THAL</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0631">
-					<td class="rtlTermCell" lang="ar">ر</td>
-					<td class="uname">U+0631</td>
-					<td class="uname">ARABIC LETTER REH</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0632">
-					<td class="rtlTermCell" lang="ar">ز</td>
-					<td class="uname">U+0632</td>
-					<td class="uname">ARABIC LETTER ZAIN</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0633">
-					<td class="rtlTermCell" lang="ar">س</td>
-					<td class="uname">U+0633</td>
-					<td class="uname">ARABIC LETTER SEEN</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0634">
-					<td class="rtlTermCell" lang="ar">ش</td>
-					<td class="uname">U+0634</td>
-					<td class="uname">ARABIC LETTER SHEEN</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0635">
-					<td class="rtlTermCell" lang="ar">ص</td>
-					<td class="uname">U+0635</td>
-					<td class="uname">ARABIC LETTER SAD</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0636">
-					<td class="rtlTermCell" lang="ar">ض</td>
-					<td class="uname">U+0636</td>
-					<td class="uname">ARABIC LETTER DAD</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0637">
-					<td class="rtlTermCell" lang="ar">ط</td>
-					<td class="uname">U+0637</td>
-					<td class="uname">ARABIC LETTER TAH</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0638">
-					<td class="rtlTermCell" lang="ar">ظ</td>
-					<td class="uname">U+0638</td>
-					<td class="uname">ARABIC LETTER ZAH</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0639">
-					<td class="rtlTermCell" lang="ar">ع</td>
-					<td class="uname">U+0639</td>
-					<td class="uname">ARABIC LETTER AIN</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+063A">
-					<td class="rtlTermCell" lang="ar">غ</td>
-					<td class="uname">U+063A</td>
-					<td class="uname">ARABIC LETTER GHAIN</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0641">
-					<td class="rtlTermCell" lang="ar">ف</td>
-					<td class="uname">U+0641</td>
-					<td class="uname">ARABIC LETTER FEH</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0642">
-					<td class="rtlTermCell" lang="ar">ق</td>
-					<td class="uname">U+0642</td>
-					<td class="uname">ARABIC LETTER QAF</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0643">
-					<td class="rtlTermCell" lang="ar">ك</td>
-					<td class="uname">U+0643</td>
-					<td class="uname">ARABIC LETTER KAF</td>
-					<td class="langMark">●</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+0644">
-					<td class="rtlTermCell" lang="ar">ل</td>
-					<td class="uname">U+0644</td>
-					<td class="uname">ARABIC LETTER LAM</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0645">
-					<td class="rtlTermCell" lang="ar">م</td>
-					<td class="uname">U+0645</td>
-					<td class="uname">ARABIC LETTER MEEM</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0646">
-					<td class="rtlTermCell" lang="ar">ن</td>
-					<td class="uname">U+0646</td>
-					<td class="uname">ARABIC LETTER NOON</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0647">
-					<td class="rtlTermCell" lang="ar">ه</td>
-					<td class="uname">U+0647</td>
-					<td class="uname">ARABIC LETTER HEH</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0648">
-					<td class="rtlTermCell" lang="ar">و</td>
-					<td class="uname">U+0648</td>
-					<td class="uname">ARABIC LETTER WAW</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0649">
-					<td class="rtlTermCell" lang="ar">ى</td>
-					<td class="uname">U+0649</td>
-					<td class="uname">ARABIC LETTER ALEF MAKSURA</td>
-					<td class="langMark">●</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+064A">
-					<td class="rtlTermCell" lang="ar">ي</td>
-					<td class="uname">U+064A</td>
-					<td class="uname">ARABIC LETTER YEH</td>
-					<td class="langMark">●</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+066F">
-					<td class="rtlTermCell" lang="ar">ٯ</td>
-					<td class="uname">U+066F</td>
-					<td class="uname">ARABIC LETTER DOTLESS QAF</td>
-					<td class="langMark">○</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+0671">
-					<td class="rtlTermCell" lang="ar">ٱ</td>
-					<td class="uname">U+0671</td>
-					<td class="uname">ARABIC LETTER ALEF WASLA</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+067E">
-					<td class="rtlTermCell" lang="ar">پ</td>
-					<td class="uname">U+067E</td>
-					<td class="uname">ARABIC LETTER PEH</td>
-					<td class="langMark">○</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0686">
-					<td class="rtlTermCell" lang="ar">چ</td>
-					<td class="uname">U+0686</td>
-					<td class="uname">ARABIC LETTER TCHEH</td>
-					<td class="langMark">○</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0698">
-					<td class="rtlTermCell" lang="ar">ژ</td>
-					<td class="uname">U+0698</td>
-					<td class="uname">ARABIC LETTER JEH</td>
-					<td class="langMark">○</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+069C">
-					<td class="rtlTermCell" lang="ar">ڜ</td>
-					<td class="uname">U+069C</td>
-					<td class="uname">ARABIC LETTER SEEN WITH THREE DOTS BELOW AND THREE DOTS ABOVE</td>
-					<td class="langMark">○</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+06A2">
-					<td class="rtlTermCell" lang="ar">ڢ</td>
-					<td class="uname">U+06A2</td>
-					<td class="uname">ARABIC LETTER FEH WITH DOT MOVED BELOW</td>
-					<td class="langMark">○</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+06A4">
-					<td class="rtlTermCell" lang="ar">ڤ</td>
-					<td class="uname">U+06A4</td>
-					<td class="uname">ARABIC LETTER VEH</td>
-					<td class="langMark">○</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+06A5">
-					<td class="rtlTermCell" lang="ar">ڥ</td>
-					<td class="uname">U+06A5</td>
-					<td class="uname">ARABIC LETTER FEH WITH THREE DOTS BELOW</td>
-					<td class="langMark">○</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+06A7">
-					<td class="rtlTermCell" lang="ar">ڧ</td>
-					<td class="uname">U+06A7</td>
-					<td class="uname">ARABIC LETTER QAF WITH DOT ABOVE</td>
-					<td class="langMark">○</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+06A8">
-					<td class="rtlTermCell" lang="ar">ڨ</td>
-					<td class="uname">U+06A8</td>
-					<td class="uname">ARABIC LETTER QAF WITH THREE DOTS ABOVE</td>
-					<td class="langMark">○</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+06A9">
-					<td class="rtlTermCell" lang="ar">ک</td>
-					<td class="uname">U+06A9</td>
-					<td class="uname">ARABIC LETTER KEHEH</td>
-					<td class="langMark">○</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+06AF">
-					<td class="rtlTermCell" lang="ar">گ</td>
-					<td class="uname">U+06AF</td>
-					<td class="uname">ARABIC LETTER GAF</td>
-					<td class="langMark">○</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+06CC">
-					<td class="rtlTermCell" lang="ar">ی</td>
-					<td class="uname">U+06CC</td>
-					<td class="uname">ARABIC LETTER FARSI YEH</td>
-					<td class="langMark">○</td>
-					<td class="langMark">●</td>
-				</tr>
-			</tbody>
-		</table>
-		<h3>Diacritics</h3>
-		<table class="characters">
-			<thead>
-				<tr>
-					<th class="charColumn">Character</th>
-					<th class="ucsColumn">UCS</th>
-					<th class="charnameColumn">Name</th>
-					<th class="languageColumn">Ar</th>
-					<th class="languageColumn">Fa</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr id="def_U+064B">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+064B.svg" alt="ً" class="charimage">
-					</td>
-					<td class="uname">U+064B</td>
-					<td class="uname">ARABIC FATHATAN</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+064C">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+064C.svg" alt="ٌ" class="charimage">
-					</td>
-					<td class="uname">U+064C</td>
-					<td class="uname">ARABIC DAMMATAN</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+064D">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+064D.svg" alt="ٍ" class="charimage">
-					</td>
-					<td class="uname">U+064D</td>
-					<td class="uname">ARABIC KASRATAN</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+064E">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+064E.svg" alt="َ" class="charimage">
-					</td>
-					<td class="uname">U+064E</td>
-					<td class="uname">ARABIC FATHA</td>
-					<td class="langMark">●</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+064F">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+064F.svg" alt="ُ" class="charimage">
-					</td>
-					<td class="uname">U+064F</td>
-					<td class="uname">ARABIC DAMMA</td>
-					<td class="langMark">●</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+0650">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+0650.svg" alt="ِ" class="charimage">
-					</td>
-					<td class="uname">U+0650</td>
-					<td class="uname">ARABIC KASRA</td>
-					<td class="langMark">●</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+0651">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+0651.svg" alt="ّ" class="charimage">
-					</td>
-					<td class="uname">U+0651</td>
-					<td class="uname">ARABIC SHADDA</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0652">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+0652.svg" alt="ْ" class="charimage">
-					</td>
-					<td class="uname">U+0652</td>
-					<td class="uname">ARABIC SUKUN</td>
-					<td class="langMark">●</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+0653">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+0653.svg" alt="ٓ" class="charimage">
-					</td>
-					<td class="uname">U+0653</td>
-					<td class="uname">ARABIC MADDAH ABOVE</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+0654">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+0654.svg" alt="ٔ" class="charimage">
-					</td>
-					<td class="uname">U+0654</td>
-					<td class="uname">ARABIC HAMZA ABOVE</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0655">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+0655.svg" alt="ٕ" class="charimage">
-					</td>
-					<td class="uname">U+0655</td>
-					<td class="uname">ARABIC HAMZA BELOW</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+0670">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+0670.svg" alt="ٰ" class="charimage">
-					</td>
-					<td class="uname">U+0670</td>
-					<td class="uname">ARABIC LETTER SUPERSCRIPT ALEF</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-			</tbody>
-		</table>
-		<h3>Numeral characters</h3>
-		<table class="characters">
-			<thead>
-				<tr>
-					<th class="charColumn">Character</th>
-					<th class="ucsColumn">UCS</th>
-					<th class="charnameColumn">Name</th>
-					<th class="languageColumn">Ar</th>
-					<th class="languageColumn">Fa</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr id="def_U+0660">
-					<td class="rtlTermCell" lang="ar">٠</td>
-					<td class="uname">U+0660</td>
-					<td class="uname">ARABIC-INDIC DIGIT ZERO</td>
-					<td class="langMark">●</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+0661">
-					<td class="rtlTermCell" lang="ar">١</td>
-					<td class="uname">U+0661</td>
-					<td class="uname">ARABIC-INDIC DIGIT ONE</td>
-					<td class="langMark">●</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+0662">
-					<td class="rtlTermCell" lang="ar">٢</td>
-					<td class="uname">U+0662</td>
-					<td class="uname">ARABIC-INDIC DIGIT TWO</td>
-					<td class="langMark">●</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+0663">
-					<td class="rtlTermCell" lang="ar">٣</td>
-					<td class="uname">U+0663</td>
-					<td class="uname">ARABIC-INDIC DIGIT THREE</td>
-					<td class="langMark">●</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+0664">
-					<td class="rtlTermCell" lang="ar">٤</td>
-					<td class="uname">U+0664</td>
-					<td class="uname">ARABIC-INDIC DIGIT FOUR</td>
-					<td class="langMark">●</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+0665">
-					<td class="rtlTermCell" lang="ar">٥</td>
-					<td class="uname">U+0665</td>
-					<td class="uname">ARABIC-INDIC DIGIT FIVE</td>
-					<td class="langMark">●</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+0666">
-					<td class="rtlTermCell" lang="ar">٦</td>
-					<td class="uname">U+0666</td>
-					<td class="uname">ARABIC-INDIC DIGIT SIX</td>
-					<td class="langMark">●</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+0667">
-					<td class="rtlTermCell" lang="ar">٧</td>
-					<td class="uname">U+0667</td>
-					<td class="uname">ARABIC-INDIC DIGIT SEVEN</td>
-					<td class="langMark">●</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+0668">
-					<td class="rtlTermCell" lang="ar">٨</td>
-					<td class="uname">U+0668</td>
-					<td class="uname">ARABIC-INDIC DIGIT EIGHT</td>
-					<td class="langMark">●</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+0669">
-					<td class="rtlTermCell" lang="ar">٩</td>
-					<td class="uname">U+0669</td>
-					<td class="uname">ARABIC-INDIC DIGIT NINE</td>
-					<td class="langMark">●</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+06F0">
-					<td class="rtlTermCell" lang="ar">۰</td>
-					<td class="uname">U+06F0</td>
-					<td class="uname">EXTENDED ARABIC-INDIC DIGIT ZERO</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+06F1">
-					<td class="rtlTermCell" lang="ar">۱</td>
-					<td class="uname">U+06F1</td>
-					<td class="uname">EXTENDED ARABIC-INDIC DIGIT ONE</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+06F2">
-					<td class="rtlTermCell" lang="ar">۲</td>
-					<td class="uname">U+06F2</td>
-					<td class="uname">EXTENDED ARABIC-INDIC DIGIT TWO</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+06F3">
-					<td class="rtlTermCell" lang="ar">۳</td>
-					<td class="uname">U+06F3</td>
-					<td class="uname">EXTENDED ARABIC-INDIC DIGIT THREE</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+06F4">
-					<td class="rtlTermCell" lang="ar">۴</td>
-					<td class="uname">U+06F4</td>
-					<td class="uname">EXTENDED ARABIC-INDIC DIGIT FOUR</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+06F5">
-					<td class="rtlTermCell" lang="ar">۵</td>
-					<td class="uname">U+06F5</td>
-					<td class="uname">EXTENDED ARABIC-INDIC DIGIT FIVE</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+06F6">
-					<td class="rtlTermCell" lang="ar">۶</td>
-					<td class="uname">U+06F6</td>
-					<td class="uname">EXTENDED ARABIC-INDIC DIGIT SIX</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+06F7">
-					<td class="rtlTermCell" lang="ar">۷</td>
-					<td class="uname">U+06F7</td>
-					<td class="uname">EXTENDED ARABIC-INDIC DIGIT SEVEN</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+06F8">
-					<td class="rtlTermCell" lang="ar">۸</td>
-					<td class="uname">U+06F8</td>
-					<td class="uname">EXTENDED ARABIC-INDIC DIGIT EIGHT</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+06F9">
-					<td class="rtlTermCell" lang="ar">۹</td>
-					<td class="uname">U+06F9</td>
-					<td class="uname">EXTENDED ARABIC-INDIC DIGIT NINE</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-			</tbody>
-		</table>
-		<h3>Punctuations and symbols</h3>
-		<table class="characters">
-			<thead>
-				<tr>
-					<th class="charColumn">Character</th>
-					<th class="ucsColumn">UCS</th>
-					<th class="charnameColumn">Name</th>
-					<th class="languageColumn">Ar</th>
-					<th class="languageColumn">Fa</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr id="def_U+00AB">
-					<td class="rtlTermCell" lang="ar">«</td>
-					<td class="uname">U+00AB</td>
-					<td class="uname">LEFT-POINTING DOUBLE ANGLE QUOTATION MARK</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+00BB">
-					<td class="rtlTermCell" lang="ar">»</td>
-					<td class="uname">U+00BB</td>
-					<td class="uname">RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+00D7">
-					<td class="rtlTermCell" lang="ar">×</td>
-					<td class="uname">U+00D7</td>
-					<td class="uname">MULTIPLICATION SIGN</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+00F7">
-					<td class="rtlTermCell" lang="ar">÷</td>
-					<td class="uname">U+00F7</td>
-					<td class="uname">DIVISION SIGN</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+060C">
-					<td class="rtlTermCell" lang="ar">،</td>
-					<td class="uname">U+060C</td>
-					<td class="uname">ARABIC COMMA</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+061B">
-					<td class="rtlTermCell" lang="ar">؛</td>
-					<td class="uname">U+061B</td>
-					<td class="uname">ARABIC SEMICOLON</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+061F">
-					<td class="rtlTermCell" lang="ar">؟</td>
-					<td class="uname">U+061F</td>
-					<td class="uname">ARABIC QUESTION MARK</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+0640">
-					<td class="rtlTermCell" lang="ar">ـ</td>
-					<td class="uname">U+0640</td>
-					<td class="uname">ARABIC TATWEEL</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+066A">
-					<td class="rtlTermCell" lang="ar">٪</td>
-					<td class="uname">U+066A</td>
-					<td class="uname">ARABIC PERCENT SIGN</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+066B">
-					<td class="rtlTermCell" lang="ar">٫</td>
-					<td class="uname">U+066B</td>
-					<td class="uname">ARABIC DECIMAL SEPARATOR</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+066C">
-					<td class="rtlTermCell" lang="ar">٬</td>
-					<td class="uname">U+066C</td>
-					<td class="uname">ARABIC THOUSANDS SEPARATOR</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+2010">
-					<td class="rtlTermCell" lang="ar">‐</td>
-					<td class="uname">U+2010</td>
-					<td class="uname">HYPHEN</td>
-					<td class="langMark">●</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+2013">
-					<td class="rtlTermCell" lang="ar">–</td>
-					<td class="uname">U+2013</td>
-					<td class="uname">EN DASH</td>
-					<td class="langMark">●</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+2014">
-					<td class="rtlTermCell" lang="ar">—</td>
-					<td class="uname">U+2014</td>
-					<td class="uname">EM DASH</td>
-					<td class="langMark">●</td>
-					<td class="langMark">✕</td>
-				</tr>
-				<tr id="def_U+2026">
-					<td class="rtlTermCell" lang="ar">…</td>
-					<td class="uname">U+2026</td>
-					<td class="uname">HORIZONTAL ELLIPSIS</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+2039">
-					<td class="rtlTermCell" lang="ar">‹</td>
-					<td class="uname">U+2039</td>
-					<td class="uname">SINGLE LEFT-POINTING ANGLE QUOTATION MARK</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+203A">
-					<td class="rtlTermCell" lang="ar">›</td>
-					<td class="uname">U+203A</td>
-					<td class="uname">SINGLE RIGHT-POINTING ANGLE QUOTATION MARK</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+2212">
-					<td class="rtlTermCell" lang="ar">−</td>
-					<td class="uname">U+2212</td>
-					<td class="uname">MINUS SIGN</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">○</td>
-				</tr>
-			</tbody>
-		</table>
-		<h3>Control characters</h3>
-		<table class="characters">
-			<thead>
-				<tr>
-					<th class="charColumn">Character</th>
-					<th class="ucsColumn">UCS</th>
-					<th class="charnameColumn">Name</th>
-					<th class="languageColumn">Ar</th>
-					<th class="languageColumn">Fa</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr id="def_U+200C">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+200C.svg" alt="‌" class="charimage">
-					</td>
-					<td class="uname">U+200C</td>
-					<td class="uname">ZERO WIDTH NON-JOINER</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+200D">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+200D.svg" alt="‍" class="charimage">
-					</td>
-					<td class="uname">U+200D</td>
-					<td class="uname">ZERO WIDTH JOINER</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+200E">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+200E.svg" alt="‎" class="charimage">
-					</td>
-					<td class="uname">U+200E</td>
-					<td class="uname">LEFT-TO-RIGHT MARK</td>
-					<td class="langMark">○</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+200F">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+200F.svg" alt="‏" class="charimage">
-					</td>
-					<td class="uname">U+200F</td>
-					<td class="uname">RIGHT-TO-LEFT MARK</td>
-					<td class="langMark">○</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+2028">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+2028.svg" alt=" " class="charimage">
-					</td>
-					<td class="uname">U+2028</td>
-					<td class="uname">LINE SEPARATOR</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+2029">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+2029.svg" alt=" " class="charimage">
-					</td>
-					<td class="uname">U+2029</td>
-					<td class="uname">PARAGRAPH SEPARATOR</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+202A">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+202A.svg" alt="‪" class="charimage">
-					</td>
-					<td class="uname">U+202A</td>
-					<td class="uname">LEFT-TO-RIGHT EMBEDDING</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+202B">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+202B.svg" alt="‫" class="charimage">
-					</td>
-					<td class="uname">U+202B</td>
-					<td class="uname">RIGHT-TO-LEFT EMBEDDING</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+202C">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+202C.svg" alt="‬" class="charimage">
-					</td>
-					<td class="uname">U+202C</td>
-					<td class="uname">POP DIRECTIONAL FORMATTING</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+202D">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+202D.svg" alt="‭" class="charimage">
-					</td>
-					<td class="uname">U+202D</td>
-					<td class="uname">LEFT-TO-RIGHT OVERRIDE</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+202E">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+202E.svg" alt="‮" class="charimage">
-					</td>
-					<td class="uname">U+202E</td>
-					<td class="uname">RIGHT-TO-LEFT OVERRIDE</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+2060">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+2060.svg" alt="⁠" class="charimage">
-					</td>
-					<td class="uname">U+2060</td>
-					<td class="uname">WORD JOINER</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-				<tr id="def_U+2066">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+2066.svg" alt="⁦" class="charimage">
-					</td>
-					<td class="uname">U+2066</td>
-					<td class="uname">LEFT-TO-RIGHT ISOLATE</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+2067">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+2067.svg" alt="⁧" class="charimage">
-					</td>
-					<td class="uname">U+2067</td>
-					<td class="uname">RIGHT-TO-LEFT ISOLATE</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+2068">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+2068.svg" alt="⁨" class="charimage">
-					</td>
-					<td class="uname">U+2068</td>
-					<td class="uname">FIRST STRONG ISOLATE</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+2069">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+2069.svg" alt="⁩" class="charimage">
-					</td>
-					<td class="uname">U+2069</td>
-					<td class="uname">POP DIRECTIONAL ISOLATE</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">○</td>
-				</tr>
-				<tr id="def_U+FEFF">
-					<td class="rtlTermCell" lang="ar">
-						<img src="images/characters/U+FEFF.svg" alt="﻿" class="charimage">
-					</td>
-					<td class="uname">U+FEFF</td>
-					<td class="uname">ZERO WIDTH NO-BREAK SPACE</td>
-					<td class="langMark">✕</td>
-					<td class="langMark">●</td>
-				</tr>
-			</tbody>
-		</table>
-		<p>Unicode 6.3 introduced directional isolate characters to replace 
-the more complicated directional embedding characters. These new 
-characters are in the process of being supported in applications and 
-their usage is encouraged over the old embedding characters. <span class="uname">U+202A LEFT-TO-RIGHT EMBEDDING</span>, <span class="uname">U+202B RIGHT-TO-LEFT EMBEDDING</span>, <span class="uname">U+202C POP DIRECTIONAL FORMATTING</span>, <span class="uname">U+202D LEFT-TO-RIGHT OVERRIDE</span>, <span class="uname">U+202E RIGHT-TO-LEFT OVERRIDE</span> are the old embedding characters and <span class="uname">U+2066 LEFT‑TO‑RIGHT ISOLATE</span>, <span class="uname">U+2067 RIGHT‑TO‑LEFT ISOLATE</span>, <span class="uname">U+2068 FIRST STRONG ISOLATE</span>, and <span class="uname">U+2069 POP DIRECTIONAL ISOLATE</span> are the new isolate characters.</p>
-		<p>Also, character <span class="uname">U+FEFF ZERO WIDTH NO-BREAK SPACE</span> is deprecated and should be replaced with <span class="uname">U+2060 WORD JOINER</span>.</p>
-	</section>
+    <p>The following tables list Unicode characters used for Arabic script,
+    excluding ASCII. Each table has two columns named <span class=
+    "qterm">Ar</span> and <span class="qterm">Fa</span> which denote which
+    characters are used for Arabic or Persian languages, respectively. A black
+    circle (●) under each of these two columns means that a character is used
+    for that language. A white circle (○) denotes a character that is auxiliary
+    for that language. An X mark (✕) means the character is not used for that
+    langauge.</p>
 
+    <h3>Alphabetical characters</h3>
 
-  
-<section class="appendix" id="glossary">
+    <table class="characters">
+      <thead>
+        <tr>
+          <th class="charColumn">Character</th>
+
+          <th class="ucsColumn">UCS</th>
+
+          <th class="charnameColumn">Name</th>
+
+          <th class="languageColumn">Ar</th>
+
+          <th class="languageColumn">Fa</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr id="def_U+0621">
+          <td class="rtlTermCell"
+              lang="ar">ء</td>
+
+          <td class="uname">U+0621</td>
+
+          <td class="uname">ARABIC LETTER HAMZA</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0622">
+          <td class="rtlTermCell"
+              lang="ar">آ</td>
+
+          <td class="uname">U+0622</td>
+
+          <td class="uname">ARABIC LETTER ALEF WITH MADDA ABOVE</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0623">
+          <td class="rtlTermCell"
+              lang="ar">أ</td>
+
+          <td class="uname">U+0623</td>
+
+          <td class="uname">ARABIC LETTER ALEF WITH HAMZA ABOVE</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0624">
+          <td class="rtlTermCell"
+              lang="ar">ؤ</td>
+
+          <td class="uname">U+0624</td>
+
+          <td class="uname">ARABIC LETTER WAW WITH HAMZA ABOVE</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0625">
+          <td class="rtlTermCell"
+              lang="ar">إ</td>
+
+          <td class="uname">U+0625</td>
+
+          <td class="uname">ARABIC LETTER ALEF WITH HAMZA BELOW</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+0626">
+          <td class="rtlTermCell"
+              lang="ar">ئ</td>
+
+          <td class="uname">U+0626</td>
+
+          <td class="uname">ARABIC LETTER YEH WITH HAMZA ABOVE</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0627">
+          <td class="rtlTermCell"
+              lang="ar">ا</td>
+
+          <td class="uname">U+0627</td>
+
+          <td class="uname">ARABIC LETTER ALEF</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0628">
+          <td class="rtlTermCell"
+              lang="ar">ب</td>
+
+          <td class="uname">U+0628</td>
+
+          <td class="uname">ARABIC LETTER BEH</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0629">
+          <td class="rtlTermCell"
+              lang="ar">ة</td>
+
+          <td class="uname">U+0629</td>
+
+          <td class="uname">ARABIC LETTER TEH MARBUTA</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+062A">
+          <td class="rtlTermCell"
+              lang="ar">ت</td>
+
+          <td class="uname">U+062A</td>
+
+          <td class="uname">ARABIC LETTER TEH</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+062B">
+          <td class="rtlTermCell"
+              lang="ar">ث</td>
+
+          <td class="uname">U+062B</td>
+
+          <td class="uname">ARABIC LETTER THEH</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+062C">
+          <td class="rtlTermCell"
+              lang="ar">ج</td>
+
+          <td class="uname">U+062C</td>
+
+          <td class="uname">ARABIC LETTER JEEM</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+062D">
+          <td class="rtlTermCell"
+              lang="ar">ح</td>
+
+          <td class="uname">U+062D</td>
+
+          <td class="uname">ARABIC LETTER HAH</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+062E">
+          <td class="rtlTermCell"
+              lang="ar">خ</td>
+
+          <td class="uname">U+062E</td>
+
+          <td class="uname">ARABIC LETTER KHAH</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+062F">
+          <td class="rtlTermCell"
+              lang="ar">د</td>
+
+          <td class="uname">U+062F</td>
+
+          <td class="uname">ARABIC LETTER DAL</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0630">
+          <td class="rtlTermCell"
+              lang="ar">ذ</td>
+
+          <td class="uname">U+0630</td>
+
+          <td class="uname">ARABIC LETTER THAL</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0631">
+          <td class="rtlTermCell"
+              lang="ar">ر</td>
+
+          <td class="uname">U+0631</td>
+
+          <td class="uname">ARABIC LETTER REH</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0632">
+          <td class="rtlTermCell"
+              lang="ar">ز</td>
+
+          <td class="uname">U+0632</td>
+
+          <td class="uname">ARABIC LETTER ZAIN</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0633">
+          <td class="rtlTermCell"
+              lang="ar">س</td>
+
+          <td class="uname">U+0633</td>
+
+          <td class="uname">ARABIC LETTER SEEN</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0634">
+          <td class="rtlTermCell"
+              lang="ar">ش</td>
+
+          <td class="uname">U+0634</td>
+
+          <td class="uname">ARABIC LETTER SHEEN</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0635">
+          <td class="rtlTermCell"
+              lang="ar">ص</td>
+
+          <td class="uname">U+0635</td>
+
+          <td class="uname">ARABIC LETTER SAD</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0636">
+          <td class="rtlTermCell"
+              lang="ar">ض</td>
+
+          <td class="uname">U+0636</td>
+
+          <td class="uname">ARABIC LETTER DAD</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0637">
+          <td class="rtlTermCell"
+              lang="ar">ط</td>
+
+          <td class="uname">U+0637</td>
+
+          <td class="uname">ARABIC LETTER TAH</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0638">
+          <td class="rtlTermCell"
+              lang="ar">ظ</td>
+
+          <td class="uname">U+0638</td>
+
+          <td class="uname">ARABIC LETTER ZAH</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0639">
+          <td class="rtlTermCell"
+              lang="ar">ع</td>
+
+          <td class="uname">U+0639</td>
+
+          <td class="uname">ARABIC LETTER AIN</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+063A">
+          <td class="rtlTermCell"
+              lang="ar">غ</td>
+
+          <td class="uname">U+063A</td>
+
+          <td class="uname">ARABIC LETTER GHAIN</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0641">
+          <td class="rtlTermCell"
+              lang="ar">ف</td>
+
+          <td class="uname">U+0641</td>
+
+          <td class="uname">ARABIC LETTER FEH</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0642">
+          <td class="rtlTermCell"
+              lang="ar">ق</td>
+
+          <td class="uname">U+0642</td>
+
+          <td class="uname">ARABIC LETTER QAF</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0643">
+          <td class="rtlTermCell"
+              lang="ar">ك</td>
+
+          <td class="uname">U+0643</td>
+
+          <td class="uname">ARABIC LETTER KAF</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+0644">
+          <td class="rtlTermCell"
+              lang="ar">ل</td>
+
+          <td class="uname">U+0644</td>
+
+          <td class="uname">ARABIC LETTER LAM</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0645">
+          <td class="rtlTermCell"
+              lang="ar">م</td>
+
+          <td class="uname">U+0645</td>
+
+          <td class="uname">ARABIC LETTER MEEM</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0646">
+          <td class="rtlTermCell"
+              lang="ar">ن</td>
+
+          <td class="uname">U+0646</td>
+
+          <td class="uname">ARABIC LETTER NOON</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0647">
+          <td class="rtlTermCell"
+              lang="ar">ه</td>
+
+          <td class="uname">U+0647</td>
+
+          <td class="uname">ARABIC LETTER HEH</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0648">
+          <td class="rtlTermCell"
+              lang="ar">و</td>
+
+          <td class="uname">U+0648</td>
+
+          <td class="uname">ARABIC LETTER WAW</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0649">
+          <td class="rtlTermCell"
+              lang="ar">ى</td>
+
+          <td class="uname">U+0649</td>
+
+          <td class="uname">ARABIC LETTER ALEF MAKSURA</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+064A">
+          <td class="rtlTermCell"
+              lang="ar">ي</td>
+
+          <td class="uname">U+064A</td>
+
+          <td class="uname">ARABIC LETTER YEH</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+066F">
+          <td class="rtlTermCell"
+              lang="ar">ٯ</td>
+
+          <td class="uname">U+066F</td>
+
+          <td class="uname">ARABIC LETTER DOTLESS QAF</td>
+
+          <td class="langMark">○</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+0671">
+          <td class="rtlTermCell"
+              lang="ar">ٱ</td>
+
+          <td class="uname">U+0671</td>
+
+          <td class="uname">ARABIC LETTER ALEF WASLA</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+067E">
+          <td class="rtlTermCell"
+              lang="ar">پ</td>
+
+          <td class="uname">U+067E</td>
+
+          <td class="uname">ARABIC LETTER PEH</td>
+
+          <td class="langMark">○</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0686">
+          <td class="rtlTermCell"
+              lang="ar">چ</td>
+
+          <td class="uname">U+0686</td>
+
+          <td class="uname">ARABIC LETTER TCHEH</td>
+
+          <td class="langMark">○</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0698">
+          <td class="rtlTermCell"
+              lang="ar">ژ</td>
+
+          <td class="uname">U+0698</td>
+
+          <td class="uname">ARABIC LETTER JEH</td>
+
+          <td class="langMark">○</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+069C">
+          <td class="rtlTermCell"
+              lang="ar">ڜ</td>
+
+          <td class="uname">U+069C</td>
+
+          <td class="uname">ARABIC LETTER SEEN WITH THREE DOTS BELOW AND THREE
+          DOTS ABOVE</td>
+
+          <td class="langMark">○</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+06A2">
+          <td class="rtlTermCell"
+              lang="ar">ڢ</td>
+
+          <td class="uname">U+06A2</td>
+
+          <td class="uname">ARABIC LETTER FEH WITH DOT MOVED BELOW</td>
+
+          <td class="langMark">○</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+06A4">
+          <td class="rtlTermCell"
+              lang="ar">ڤ</td>
+
+          <td class="uname">U+06A4</td>
+
+          <td class="uname">ARABIC LETTER VEH</td>
+
+          <td class="langMark">○</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+06A5">
+          <td class="rtlTermCell"
+              lang="ar">ڥ</td>
+
+          <td class="uname">U+06A5</td>
+
+          <td class="uname">ARABIC LETTER FEH WITH THREE DOTS BELOW</td>
+
+          <td class="langMark">○</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+06A7">
+          <td class="rtlTermCell"
+              lang="ar">ڧ</td>
+
+          <td class="uname">U+06A7</td>
+
+          <td class="uname">ARABIC LETTER QAF WITH DOT ABOVE</td>
+
+          <td class="langMark">○</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+06A8">
+          <td class="rtlTermCell"
+              lang="ar">ڨ</td>
+
+          <td class="uname">U+06A8</td>
+
+          <td class="uname">ARABIC LETTER QAF WITH THREE DOTS ABOVE</td>
+
+          <td class="langMark">○</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+06A9">
+          <td class="rtlTermCell"
+              lang="ar">ک</td>
+
+          <td class="uname">U+06A9</td>
+
+          <td class="uname">ARABIC LETTER KEHEH</td>
+
+          <td class="langMark">○</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+06AF">
+          <td class="rtlTermCell"
+              lang="ar">گ</td>
+
+          <td class="uname">U+06AF</td>
+
+          <td class="uname">ARABIC LETTER GAF</td>
+
+          <td class="langMark">○</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+06CC">
+          <td class="rtlTermCell"
+              lang="ar">ی</td>
+
+          <td class="uname">U+06CC</td>
+
+          <td class="uname">ARABIC LETTER FARSI YEH</td>
+
+          <td class="langMark">○</td>
+
+          <td class="langMark">●</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>Diacritics</h3>
+
+    <table class="characters">
+      <thead>
+        <tr>
+          <th class="charColumn">Character</th>
+
+          <th class="ucsColumn">UCS</th>
+
+          <th class="charnameColumn">Name</th>
+
+          <th class="languageColumn">Ar</th>
+
+          <th class="languageColumn">Fa</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr id="def_U+064B">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+064B.svg"
+               alt="ً"
+               class="charimage"></td>
+
+          <td class="uname">U+064B</td>
+
+          <td class="uname">ARABIC FATHATAN</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+064C">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+064C.svg"
+               alt="ٌ"
+               class="charimage"></td>
+
+          <td class="uname">U+064C</td>
+
+          <td class="uname">ARABIC DAMMATAN</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+064D">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+064D.svg"
+               alt="ٍ"
+               class="charimage"></td>
+
+          <td class="uname">U+064D</td>
+
+          <td class="uname">ARABIC KASRATAN</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+064E">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+064E.svg"
+               alt="َ"
+               class="charimage"></td>
+
+          <td class="uname">U+064E</td>
+
+          <td class="uname">ARABIC FATHA</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+064F">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+064F.svg"
+               alt="ُ"
+               class="charimage"></td>
+
+          <td class="uname">U+064F</td>
+
+          <td class="uname">ARABIC DAMMA</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+0650">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+0650.svg"
+               alt="ِ"
+               class="charimage"></td>
+
+          <td class="uname">U+0650</td>
+
+          <td class="uname">ARABIC KASRA</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+0651">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+0651.svg"
+               alt="ّ"
+               class="charimage"></td>
+
+          <td class="uname">U+0651</td>
+
+          <td class="uname">ARABIC SHADDA</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0652">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+0652.svg"
+               alt="ْ"
+               class="charimage"></td>
+
+          <td class="uname">U+0652</td>
+
+          <td class="uname">ARABIC SUKUN</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+0653">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+0653.svg"
+               alt="ٓ"
+               class="charimage"></td>
+
+          <td class="uname">U+0653</td>
+
+          <td class="uname">ARABIC MADDAH ABOVE</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+0654">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+0654.svg"
+               alt="ٔ"
+               class="charimage"></td>
+
+          <td class="uname">U+0654</td>
+
+          <td class="uname">ARABIC HAMZA ABOVE</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0655">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+0655.svg"
+               alt="ٕ"
+               class="charimage"></td>
+
+          <td class="uname">U+0655</td>
+
+          <td class="uname">ARABIC HAMZA BELOW</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+0670">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+0670.svg"
+               alt="ٰ"
+               class="charimage"></td>
+
+          <td class="uname">U+0670</td>
+
+          <td class="uname">ARABIC LETTER SUPERSCRIPT ALEF</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>Numeral characters</h3>
+
+    <table class="characters">
+      <thead>
+        <tr>
+          <th class="charColumn">Character</th>
+
+          <th class="ucsColumn">UCS</th>
+
+          <th class="charnameColumn">Name</th>
+
+          <th class="languageColumn">Ar</th>
+
+          <th class="languageColumn">Fa</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr id="def_U+0660">
+          <td class="rtlTermCell"
+              lang="ar">٠</td>
+
+          <td class="uname">U+0660</td>
+
+          <td class="uname">ARABIC-INDIC DIGIT ZERO</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+0661">
+          <td class="rtlTermCell"
+              lang="ar">١</td>
+
+          <td class="uname">U+0661</td>
+
+          <td class="uname">ARABIC-INDIC DIGIT ONE</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+0662">
+          <td class="rtlTermCell"
+              lang="ar">٢</td>
+
+          <td class="uname">U+0662</td>
+
+          <td class="uname">ARABIC-INDIC DIGIT TWO</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+0663">
+          <td class="rtlTermCell"
+              lang="ar">٣</td>
+
+          <td class="uname">U+0663</td>
+
+          <td class="uname">ARABIC-INDIC DIGIT THREE</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+0664">
+          <td class="rtlTermCell"
+              lang="ar">٤</td>
+
+          <td class="uname">U+0664</td>
+
+          <td class="uname">ARABIC-INDIC DIGIT FOUR</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+0665">
+          <td class="rtlTermCell"
+              lang="ar">٥</td>
+
+          <td class="uname">U+0665</td>
+
+          <td class="uname">ARABIC-INDIC DIGIT FIVE</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+0666">
+          <td class="rtlTermCell"
+              lang="ar">٦</td>
+
+          <td class="uname">U+0666</td>
+
+          <td class="uname">ARABIC-INDIC DIGIT SIX</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+0667">
+          <td class="rtlTermCell"
+              lang="ar">٧</td>
+
+          <td class="uname">U+0667</td>
+
+          <td class="uname">ARABIC-INDIC DIGIT SEVEN</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+0668">
+          <td class="rtlTermCell"
+              lang="ar">٨</td>
+
+          <td class="uname">U+0668</td>
+
+          <td class="uname">ARABIC-INDIC DIGIT EIGHT</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+0669">
+          <td class="rtlTermCell"
+              lang="ar">٩</td>
+
+          <td class="uname">U+0669</td>
+
+          <td class="uname">ARABIC-INDIC DIGIT NINE</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+06F0">
+          <td class="rtlTermCell"
+              lang="ar">۰</td>
+
+          <td class="uname">U+06F0</td>
+
+          <td class="uname">EXTENDED ARABIC-INDIC DIGIT ZERO</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+06F1">
+          <td class="rtlTermCell"
+              lang="ar">۱</td>
+
+          <td class="uname">U+06F1</td>
+
+          <td class="uname">EXTENDED ARABIC-INDIC DIGIT ONE</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+06F2">
+          <td class="rtlTermCell"
+              lang="ar">۲</td>
+
+          <td class="uname">U+06F2</td>
+
+          <td class="uname">EXTENDED ARABIC-INDIC DIGIT TWO</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+06F3">
+          <td class="rtlTermCell"
+              lang="ar">۳</td>
+
+          <td class="uname">U+06F3</td>
+
+          <td class="uname">EXTENDED ARABIC-INDIC DIGIT THREE</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+06F4">
+          <td class="rtlTermCell"
+              lang="ar">۴</td>
+
+          <td class="uname">U+06F4</td>
+
+          <td class="uname">EXTENDED ARABIC-INDIC DIGIT FOUR</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+06F5">
+          <td class="rtlTermCell"
+              lang="ar">۵</td>
+
+          <td class="uname">U+06F5</td>
+
+          <td class="uname">EXTENDED ARABIC-INDIC DIGIT FIVE</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+06F6">
+          <td class="rtlTermCell"
+              lang="ar">۶</td>
+
+          <td class="uname">U+06F6</td>
+
+          <td class="uname">EXTENDED ARABIC-INDIC DIGIT SIX</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+06F7">
+          <td class="rtlTermCell"
+              lang="ar">۷</td>
+
+          <td class="uname">U+06F7</td>
+
+          <td class="uname">EXTENDED ARABIC-INDIC DIGIT SEVEN</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+06F8">
+          <td class="rtlTermCell"
+              lang="ar">۸</td>
+
+          <td class="uname">U+06F8</td>
+
+          <td class="uname">EXTENDED ARABIC-INDIC DIGIT EIGHT</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+06F9">
+          <td class="rtlTermCell"
+              lang="ar">۹</td>
+
+          <td class="uname">U+06F9</td>
+
+          <td class="uname">EXTENDED ARABIC-INDIC DIGIT NINE</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>Punctuations and symbols</h3>
+
+    <table class="characters">
+      <thead>
+        <tr>
+          <th class="charColumn">Character</th>
+
+          <th class="ucsColumn">UCS</th>
+
+          <th class="charnameColumn">Name</th>
+
+          <th class="languageColumn">Ar</th>
+
+          <th class="languageColumn">Fa</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr id="def_U+00AB">
+          <td class="rtlTermCell"
+              lang="ar">«</td>
+
+          <td class="uname">U+00AB</td>
+
+          <td class="uname">LEFT-POINTING DOUBLE ANGLE QUOTATION MARK</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+00BB">
+          <td class="rtlTermCell"
+              lang="ar">»</td>
+
+          <td class="uname">U+00BB</td>
+
+          <td class="uname">RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+00D7">
+          <td class="rtlTermCell"
+              lang="ar">×</td>
+
+          <td class="uname">U+00D7</td>
+
+          <td class="uname">MULTIPLICATION SIGN</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+00F7">
+          <td class="rtlTermCell"
+              lang="ar">÷</td>
+
+          <td class="uname">U+00F7</td>
+
+          <td class="uname">DIVISION SIGN</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+060C">
+          <td class="rtlTermCell"
+              lang="ar">،</td>
+
+          <td class="uname">U+060C</td>
+
+          <td class="uname">ARABIC COMMA</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+061B">
+          <td class="rtlTermCell"
+              lang="ar">؛</td>
+
+          <td class="uname">U+061B</td>
+
+          <td class="uname">ARABIC SEMICOLON</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+061F">
+          <td class="rtlTermCell"
+              lang="ar">؟</td>
+
+          <td class="uname">U+061F</td>
+
+          <td class="uname">ARABIC QUESTION MARK</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+0640">
+          <td class="rtlTermCell"
+              lang="ar">ـ</td>
+
+          <td class="uname">U+0640</td>
+
+          <td class="uname">ARABIC TATWEEL</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+066A">
+          <td class="rtlTermCell"
+              lang="ar">٪</td>
+
+          <td class="uname">U+066A</td>
+
+          <td class="uname">ARABIC PERCENT SIGN</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+066B">
+          <td class="rtlTermCell"
+              lang="ar">٫</td>
+
+          <td class="uname">U+066B</td>
+
+          <td class="uname">ARABIC DECIMAL SEPARATOR</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+066C">
+          <td class="rtlTermCell"
+              lang="ar">٬</td>
+
+          <td class="uname">U+066C</td>
+
+          <td class="uname">ARABIC THOUSANDS SEPARATOR</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+2010">
+          <td class="rtlTermCell"
+              lang="ar">‐</td>
+
+          <td class="uname">U+2010</td>
+
+          <td class="uname">HYPHEN</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+2013">
+          <td class="rtlTermCell"
+              lang="ar">–</td>
+
+          <td class="uname">U+2013</td>
+
+          <td class="uname">EN DASH</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+2014">
+          <td class="rtlTermCell"
+              lang="ar">—</td>
+
+          <td class="uname">U+2014</td>
+
+          <td class="uname">EM DASH</td>
+
+          <td class="langMark">●</td>
+
+          <td class="langMark">✕</td>
+        </tr>
+
+        <tr id="def_U+2026">
+          <td class="rtlTermCell"
+              lang="ar">…</td>
+
+          <td class="uname">U+2026</td>
+
+          <td class="uname">HORIZONTAL ELLIPSIS</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+2039">
+          <td class="rtlTermCell"
+              lang="ar">‹</td>
+
+          <td class="uname">U+2039</td>
+
+          <td class="uname">SINGLE LEFT-POINTING ANGLE QUOTATION MARK</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+203A">
+          <td class="rtlTermCell"
+              lang="ar">›</td>
+
+          <td class="uname">U+203A</td>
+
+          <td class="uname">SINGLE RIGHT-POINTING ANGLE QUOTATION MARK</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+2212">
+          <td class="rtlTermCell"
+              lang="ar">−</td>
+
+          <td class="uname">U+2212</td>
+
+          <td class="uname">MINUS SIGN</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">○</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>Control characters</h3>
+
+    <table class="characters">
+      <thead>
+        <tr>
+          <th class="charColumn">Character</th>
+
+          <th class="ucsColumn">UCS</th>
+
+          <th class="charnameColumn">Name</th>
+
+          <th class="languageColumn">Ar</th>
+
+          <th class="languageColumn">Fa</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr id="def_U+200C">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+200C.svg"
+               alt="‌"
+               class="charimage"></td>
+
+          <td class="uname">U+200C</td>
+
+          <td class="uname">ZERO WIDTH NON-JOINER</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+200D">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+200D.svg"
+               alt="‍"
+               class="charimage"></td>
+
+          <td class="uname">U+200D</td>
+
+          <td class="uname">ZERO WIDTH JOINER</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+200E">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+200E.svg"
+               alt="‎"
+               class="charimage"></td>
+
+          <td class="uname">U+200E</td>
+
+          <td class="uname">LEFT-TO-RIGHT MARK</td>
+
+          <td class="langMark">○</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+200F">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+200F.svg"
+               alt="‏"
+               class="charimage"></td>
+
+          <td class="uname">U+200F</td>
+
+          <td class="uname">RIGHT-TO-LEFT MARK</td>
+
+          <td class="langMark">○</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+2028">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+2028.svg"
+               alt=" "
+               class="charimage"></td>
+
+          <td class="uname">U+2028</td>
+
+          <td class="uname">LINE SEPARATOR</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+2029">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+2029.svg"
+               alt=" "
+               class="charimage"></td>
+
+          <td class="uname">U+2029</td>
+
+          <td class="uname">PARAGRAPH SEPARATOR</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+202A">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+202A.svg"
+               alt="‪"
+               class="charimage"></td>
+
+          <td class="uname">U+202A</td>
+
+          <td class="uname">LEFT-TO-RIGHT EMBEDDING</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+202B">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+202B.svg"
+               alt="‫"
+               class="charimage"></td>
+
+          <td class="uname">U+202B</td>
+
+          <td class="uname">RIGHT-TO-LEFT EMBEDDING</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+202C">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+202C.svg"
+               alt="‬"
+               class="charimage"></td>
+
+          <td class="uname">U+202C</td>
+
+          <td class="uname">POP DIRECTIONAL FORMATTING</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+202D">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+202D.svg"
+               alt="‭"
+               class="charimage"></td>
+
+          <td class="uname">U+202D</td>
+
+          <td class="uname">LEFT-TO-RIGHT OVERRIDE</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+202E">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+202E.svg"
+               alt="‮"
+               class="charimage"></td>
+
+          <td class="uname">U+202E</td>
+
+          <td class="uname">RIGHT-TO-LEFT OVERRIDE</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+2060">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+2060.svg"
+               alt="⁠"
+               class="charimage"></td>
+
+          <td class="uname">U+2060</td>
+
+          <td class="uname">WORD JOINER</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+
+        <tr id="def_U+2066">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+2066.svg"
+               alt="⁦"
+               class="charimage"></td>
+
+          <td class="uname">U+2066</td>
+
+          <td class="uname">LEFT-TO-RIGHT ISOLATE</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+2067">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+2067.svg"
+               alt="⁧"
+               class="charimage"></td>
+
+          <td class="uname">U+2067</td>
+
+          <td class="uname">RIGHT-TO-LEFT ISOLATE</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+2068">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+2068.svg"
+               alt="⁨"
+               class="charimage"></td>
+
+          <td class="uname">U+2068</td>
+
+          <td class="uname">FIRST STRONG ISOLATE</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+2069">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+2069.svg"
+               alt="⁩"
+               class="charimage"></td>
+
+          <td class="uname">U+2069</td>
+
+          <td class="uname">POP DIRECTIONAL ISOLATE</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">○</td>
+        </tr>
+
+        <tr id="def_U+FEFF">
+          <td class="rtlTermCell"
+              lang="ar"><img src="images/characters/U+FEFF.svg"
+               alt="﻿"
+               class="charimage"></td>
+
+          <td class="uname">U+FEFF</td>
+
+          <td class="uname">ZERO WIDTH NO-BREAK SPACE</td>
+
+          <td class="langMark">✕</td>
+
+          <td class="langMark">●</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>Unicode 6.3 introduced directional isolate characters to replace the
+    more complicated directional embedding characters. These new characters are
+    in the process of being supported in applications and their usage is
+    encouraged over the old embedding characters. <span class="uname">U+202A
+    LEFT-TO-RIGHT EMBEDDING</span>, <span class="uname">U+202B RIGHT-TO-LEFT
+    EMBEDDING</span>, <span class="uname">U+202C POP DIRECTIONAL
+    FORMATTING</span>, <span class="uname">U+202D LEFT-TO-RIGHT
+    OVERRIDE</span>, <span class="uname">U+202E RIGHT-TO-LEFT OVERRIDE</span>
+    are the old embedding characters and <span class="uname">U+2066
+    LEFT‑TO‑RIGHT ISOLATE</span>, <span class="uname">U+2067 RIGHT‑TO‑LEFT
+    ISOLATE</span>, <span class="uname">U+2068 FIRST STRONG ISOLATE</span>, and
+    <span class="uname">U+2069 POP DIRECTIONAL ISOLATE</span> are the new
+    isolate characters.</p>
+
+    <p>Also, character <span class="uname">U+FEFF ZERO WIDTH NO-BREAK
+    SPACE</span> is deprecated and should be replaced with <span class=
+    "uname">U+2060 WORD JOINER</span>.</p>
+  </section>
+
+  <section class="appendix"
+           id="glossary">
     <h2>Glossary</h2>
+
     <table class="glossary">
       <thead>
         <tr>
           <th>Term</th>
+
           <th>Arabic</th>
+
           <th>Persian</th>
+
           <th>Definition</th>
         </tr>
       </thead>
+
       <tbody>
         <tr id="def_alignment">
           <td>alignment</td>
+
           <td class="rtlTermCell">مُحاذاة، تَرصِيف</td>
+
           <td class="rtlTermCell">هم‌ترازی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_alphanumeric">
           <td>alphanumeric</td>
+
           <td class="rtlTermCell">أَبجَدِي عَدَدِي</td>
+
           <td class="rtlTermCell">الفبایی عددی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_appendix">
           <td>appendix</td>
+
           <td class="rtlTermCell">مُلحَق</td>
+
           <td class="rtlTermCell">ضمیمه</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_arabicnumerals">
           <td>arabic numerals</td>
+
           <td class="rtlTermCell">أرقام عربية، أرقام أوروبية</td>
+
           <td class="rtlTermCell">ارقام عربی</td>
-          <td>Refer to "European numerals". Use "European numerals" or "ASCII numerals" to avoid
-          confusion.</td>
+
+          <td>Refer to "European numerals". Use "European numerals" or "ASCII
+          numerals" to avoid confusion.</td>
         </tr>
+
         <tr id="def_ascender">
           <td>ascender</td>
+
           <td class="rtlTermCell">صاعد</td>
+
           <td class="rtlTermCell">خط صعود، کرسی بالا</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_asterisk">
           <td>asterisk</td>
+
           <td class="rtlTermCell">نجمة</td>
+
           <td class="rtlTermCell">ستاره</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_autospacing">
           <td>auto spacing</td>
+
           <td class="rtlTermCell">تباعد، فراغ آلي</td>
+
           <td class="rtlTermCell">فاصله‌گذاری خودکار</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_backmargin">
           <td>back margin</td>
+
           <td class="rtlTermCell">هامش، الهامش الخلفي</td>
+
           <td class="rtlTermCell">حاشیهٔ داخلی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_backmatter">
           <td>back matter</td>
+
           <td class="rtlTermCell">بيانات نهاية الكتاب</td>
+
           <td class="rtlTermCell">واحدهای پس از متن</td>
-          <td>Appendices, supplements, glossary of terms, index and/or bibliography, and so on,
-          appended at the end of a book.</td>
+
+          <td>Appendices, supplements, glossary of terms, index and/or
+          bibliography, and so on, appended at the end of a book.</td>
         </tr>
+
         <tr id="def_badbreak">
           <td>bad break</td>
+
           <td class="rtlTermCell">قطع سيئ</td>
+
           <td class="rtlTermCell">شکستن بد، سطرشکنی بد</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_baseline">
           <td>baseline</td>
+
           <td class="rtlTermCell">سطر الأساس</td>
+
           <td class="rtlTermCell">خط کرسی</td>
-          <td>A virtual line on which almost all glyphs in Western fonts are designed to be
-          aligned.</td>
+
+          <td>A virtual line on which almost all glyphs in Western fonts are
+          designed to be aligned.</td>
         </tr>
+
         <tr id="def_bibliography">
           <td>bibliography</td>
+
           <td class="rtlTermCell">قائمة المراجع، البيبليوغرافيا</td>
+
           <td class="rtlTermCell">کتابنامه</td>
-          <td>A list of works and papers related to the subjects in the text.</td>
+
+          <td>A list of works and papers related to the subjects in the
+          text.</td>
         </tr>
+
         <tr id="def_blankpage">
           <td>blank page</td>
+
           <td class="rtlTermCell">صفحة فارغة</td>
+
           <td class="rtlTermCell">صفحهٔ خالی</td>
+
           <td>An empty page.</td>
         </tr>
+
         <tr id="def_bleed">
           <td>bleed</td>
+
           <td class="rtlTermCell">خارج إطار الصفحة</td>
+
           <td class="rtlTermCell">تصویرْ تا بُرِش</td>
-          <td>To print a picture or a tint to run off the edge of a trimmed page.</td>
+
+          <td>To print a picture or a tint to run off the edge of a trimmed
+          page.</td>
         </tr>
+
         <tr id="def_blockdirection">
           <td>block direction</td>
+
           <td class="rtlTermCell">اتجاه المقطع، اتجاه الكتلة</td>
+
           <td class="rtlTermCell">جهت نوشتار</td>
+
           <td>The progression direction of lines, one after the other.</td>
         </tr>
+
         <tr id="def_blockquotation">
           <td>block quotation</td>
+
           <td class="rtlTermCell">كتلة اقتباس، مربع اقتباس</td>
+
           <td class="rtlTermCell">نقل‌قول&nbsp;پاراگرافی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_bodytype">
           <td>body type</td>
+
           <td class="rtlTermCell">الخط الرئيسي</td>
+
           <td class="rtlTermCell">حروف بدنه</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_bold">
           <td>bold</td>
+
           <td class="rtlTermCell">عريض، غليظ</td>
+
           <td class="rtlTermCell">حرف سیاه</td>
+
           <td>A kind of font style. Similar to bold in Western typograpy.</td>
         </tr>
+
         <tr id="def_boldface">
           <td>boldface</td>
+
           <td class="rtlTermCell">خط عريض، بنط عريض</td>
+
           <td class="rtlTermCell">حرف سیاه</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_boundontheleft-handside">
           <td>bound on the left-hand side</td>
+
           <td class="rtlTermCell">ملزمة على الجانب الأيسر</td>
+
           <td class="rtlTermCell">صحافی چپ‌به‌راست</td>
+
           <td>Binding of a book to be opened from the left.</td>
         </tr>
+
         <tr id="def_boundontheright-handside">
           <td>bound on the right-hand side</td>
+
           <td class="rtlTermCell">ملزمة على الجانب الأيمن</td>
+
           <td class="rtlTermCell">صحافی راست‌به‌چپ</td>
+
           <td>Binding of a book to be opened from the right.</td>
         </tr>
+
         <tr id="def_boundingbox">
           <td>bounding box</td>
+
           <td class="rtlTermCell">الصندوق المحيط</td>
+
           <td class="rtlTermCell">کادر محیطی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_box">
           <td>box</td>
+
           <td class="rtlTermCell">صندوق</td>
+
           <td class="rtlTermCell">کادر، جعبه</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_braces">
           <td>braces</td>
+
           <td class="rtlTermCell">أقواس هلالية</td>
+
           <td class="rtlTermCell">آکولاد</td>
+
           <td>{ and }</td>
         </tr>
+
         <tr id="def_brackets">
           <td>brackets</td>
+
           <td class="rtlTermCell">أقواس مربعة</td>
+
           <td class="rtlTermCell">کروشه</td>
+
           <td>[ and ]</td>
         </tr>
+
         <tr id="def_break(aline)">
           <td>break (a line)</td>
+
           <td class="rtlTermCell">فصل السطر، قطع (سطر)</td>
+
           <td class="rtlTermCell">شکستن (خط)، سطرشکنی</td>
-          <td>To place the first of two adjacent characters at the end of a line and the second at
-          the head of a new line.</td>
+
+          <td>To place the first of two adjacent characters at the end of a
+          line and the second at the head of a new line.</td>
         </tr>
+
         <tr id="def_broadside">
           <td>broadside</td>
+
           <td class="rtlTermCell">وضع جانبي</td>
+
           <td class="rtlTermCell">یک‌رو</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_bullet">
           <td>bullet</td>
+
           <td class="rtlTermCell">رمز نقطي</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td>centered dot</td>
         </tr>
+
         <tr id="def_calligraphy">
           <td>calligraphy</td>
+
           <td class="rtlTermCell">فن الخط، الخط</td>
+
           <td class="rtlTermCell">خوشنویسی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_caption">
           <td>caption</td>
+
           <td class="rtlTermCell">تسمية، عنوان</td>
+
           <td class="rtlTermCell">عنوان، شرح</td>
-          <td>A title or a short description accompanying a picture, an illustration, or a
-          table.</td>
+
+          <td>A title or a short description accompanying a picture, an
+          illustration, or a table.</td>
         </tr>
+
         <tr id="def_cell">
           <td>cell</td>
+
           <td class="rtlTermCell">خلية، خانة</td>
+
           <td class="rtlTermCell">سلول</td>
+
           <td>Each element area of tables, cell.</td>
         </tr>
+
         <tr id="def_cellcontents">
           <td>cell contents</td>
+
           <td class="rtlTermCell">محتوى الخلية، محتوى الخانة</td>
+
           <td class="rtlTermCell">محتوای سلول</td>
+
           <td>The content of each cell in tables.</td>
         </tr>
+
         <tr id="def_cellpadding">
           <td>cell padding</td>
+
           <td class="rtlTermCell">حشو الخلية، حشو الخانة</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td>Spaces between line and cell in tables.</td>
         </tr>
+
         <tr id="def_centeredalignment">
           <td>centered alignment</td>
+
           <td class="rtlTermCell">توسيط</td>
+
           <td class="rtlTermCell">ترازبندی وسط‌چین</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_centereddot">
           <td>centered dot</td>
+
           <td class="rtlTermCell">نقطة موسّطة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_centering">
           <td>centering</td>
+
           <td class="rtlTermCell">توسيط</td>
+
           <td class="rtlTermCell">وسط‌چین کردن</td>
-          <td>To align the center of a run of text that is shorter than a given line length to the
-          center of a line.</td>
+
+          <td>To align the center of a run of text that is shorter than a given
+          line length to the center of a line.</td>
         </tr>
+
         <tr id="def_chapter">
           <td>chapter</td>
+
           <td class="rtlTermCell">فصل، باب</td>
+
           <td class="rtlTermCell">فصل</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_character">
           <td>character</td>
+
           <td class="rtlTermCell">حرف</td>
+
           <td class="rtlTermCell">حرف</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_charactercount">
           <td>character count</td>
+
           <td class="rtlTermCell">عدد الأحرف</td>
+
           <td class="rtlTermCell">تعداد حروف</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_characterframe">
           <td>character frame</td>
+
           <td class="rtlTermCell">إطار الحرف</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>Rectangular area occupied by a character when it is set solid.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>Rectangular area occupied by a character when it is set
+          solid.</td>
         </tr>
+
         <tr id="def_characterset">
           <td>character set</td>
+
           <td class="rtlTermCell">مجموعة حروف</td>
+
           <td class="rtlTermCell">مجموعهٔ حروف</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_charactershape">
           <td>character shape</td>
+
           <td class="rtlTermCell">شكل الحرف</td>
+
           <td class="rtlTermCell">شکل حرف</td>
-          <td>Incarnation of a character by handwriting, printing or rendering to a computer
-          screen.</td>
+
+          <td>Incarnation of a character by handwriting, printing or rendering
+          to a computer screen.</td>
         </tr>
+
         <tr id="def_charactersize">
           <td>character size</td>
+
           <td class="rtlTermCell">حجم الحرف</td>
+
           <td class="rtlTermCell">اندازهٔ حرف</td>
-          <td>Dimensions of a character. Unless otherwise noted, it refers to the size of a
-          character frame in the block direction.</td>
+
+          <td>Dimensions of a character. Unless otherwise noted, it refers to
+          the size of a character frame in the block direction.</td>
         </tr>
+
         <tr id="def_closingbracket">
           <td>closing bracket</td>
+
           <td class="rtlTermCell">قوس إغلاق</td>
+
           <td class="rtlTermCell">کروشه بسته</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_codepoint">
           <td>code point</td>
+
           <td class="rtlTermCell">نقطة ترميز</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_colon">
           <td>colon</td>
+
           <td class="rtlTermCell">نقطتين</td>
+
           <td class="rtlTermCell">دونقطه</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_column">
           <td>column</td>
+
           <td class="rtlTermCell">عمود</td>
+
           <td class="rtlTermCell">ستون</td>
+
           <td>A partition on a page in multi-column format.</td>
         </tr>
+
         <tr id="def_columngap">
           <td>column gap</td>
+
           <td class="rtlTermCell">تباعد الأعمدة</td>
+
           <td class="rtlTermCell">فاصلهٔ ستون</td>
+
           <td>Amount of space between columns on a page.</td>
         </tr>
+
         <tr id="def_columnspanning">
           <td>column spanning</td>
+
           <td class="rtlTermCell">عبر الأعمدة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A setting style of illustrations, tables, etc., over hanging to multiple
-          columns.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A setting style of illustrations, tables, etc., over hanging to
+          multiple columns.</td>
         </tr>
+
         <tr id="def_columnspanningheading">
           <td>column spanning heading</td>
+
           <td class="rtlTermCell">رأس عبر الأعمدة</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td>Headings using multiple columns.</td>
         </tr>
+
         <tr id="def_comma">
           <td>comma</td>
+
           <td class="rtlTermCell">فاصلة</td>
+
           <td class="rtlTermCell">ویرگول</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_composition">
           <td>composition</td>
+
           <td class="rtlTermCell">تركيب</td>
+
           <td class="rtlTermCell">حروفچینی و صفحه‌بندی</td>
-          <td>Process of arrangement of text, figures and/or pictures, etc on a page in a desired
-          layout (design) in preparation for printing.</td>
+
+          <td>Process of arrangement of text, figures and/or pictures, etc on a
+          page in a desired layout (design) in preparation for printing.</td>
         </tr>
+
         <tr id="def_compoundword">
           <td>compound word</td>
+
           <td class="rtlTermCell">کلمة مرکبة</td>
+
           <td class="rtlTermCell">کلمهٔ مرکب</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_continuouspagination">
           <td>continuous pagination</td>
+
           <td class="rtlTermCell">ترقيم الصفحات المستمر</td>
+
           <td class="rtlTermCell">صفحه‌شماری پیوسته</td>
-          <td>a) To number the pages of a book continuously across all those in the front matter,
-          the text and the back matter. b) To number the pages continuously across those of all
-          books, such as a series published in separate volumes. Also to number the pages
-          continuously across those of all issues of a periodical published in a year, aside from
-          pagination per issue.</td>
+
+          <td>a) To number the pages of a book continuously across all those in
+          the front matter, the text and the back matter. b) To number the
+          pages continuously across those of all books, such as a series
+          published in separate volumes. Also to number the pages continuously
+          across those of all issues of a periodical published in a year, aside
+          from pagination per issue.</td>
         </tr>
+
         <tr id="def_controlcharacters">
           <td>control characters</td>
+
           <td class="rtlTermCell">حروف تحكم</td>
+
           <td class="rtlTermCell">حروف کنترلی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_copy">
           <td>copy</td>
+
           <td class="rtlTermCell">نسخة</td>
+
           <td class="rtlTermCell">نسخه</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_cover">
           <td>cover</td>
+
           <td class="rtlTermCell">غلاف</td>
+
           <td class="rtlTermCell">جلد</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_cut-inheading">
           <td>cut-in heading</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A style of headings. Headings do not occupy the full lines, but share lines area with
-          following main text lines.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A style of headings. Headings do not occupy the full lines, but
+          share lines area with following main text lines.</td>
         </tr>
+
         <tr id="def_dash">
           <td>dash</td>
+
           <td class="rtlTermCell">واصلة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_dedication">
           <td>dedication</td>
+
           <td class="rtlTermCell">إهداء</td>
+
           <td class="rtlTermCell">اهدائیه</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_descenderline">
           <td>descender line</td>
+
           <td class="rtlTermCell">خط النازل</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A descender is the part of a letter extending below the base line, as in 'g', 'j',
-          'p', 'q', or 'y'. A descender line is a virtual line drawn at the bottom of descender
-          parallel to base line.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A descender is the part of a letter extending below the base
+          line, as in 'g', 'j', 'p', 'q', or 'y'. A descender line is a virtual
+          line drawn at the bottom of descender parallel to base line.</td>
         </tr>
+
         <tr id="def_diacriticalmarks">
           <td>diacritical marks</td>
+
           <td class="rtlTermCell">علامات التشكيل</td>
+
           <td class="rtlTermCell">اِعراب، نشانه‌های حروف</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_diagonalfraction">
           <td>diagonal fraction</td>
+
           <td class="rtlTermCell">الكَسْرُ القُطْري</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_diagram">
           <td>diagram</td>
+
           <td class="rtlTermCell">رسم بياني، رسم تخطيطي</td>
+
           <td class="rtlTermCell">نمودار</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_discretionaryhyphen">
           <td>discretionary hyphen</td>
+
           <td class="rtlTermCell">واصلة لينة</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td>See "soft hyphen".</td>
         </tr>
+
         <tr id="def_display">
           <td>display</td>
+
           <td class="rtlTermCell">عرض</td>
+
           <td class="rtlTermCell">نمایش</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_displaytype">
           <td>display type</td>
+
           <td class="rtlTermCell">نوع العرض</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_document">
           <td>document</td>
+
           <td class="rtlTermCell">وثيقة، مستند</td>
+
           <td class="rtlTermCell">سند</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_dpi">
           <td>dpi</td>
+
           <td class="rtlTermCell">نقطة في البوصة</td>
+
           <td class="rtlTermCell">نقطه در اینچ</td>
-          <td>Dots per inch (DPI, or dpi) is a measure of spatial printing.</td>
+
+          <td>Dots per inch (DPI, or dpi) is a measure of spatial
+          printing.</td>
         </tr>
+
         <tr id="def_easternarabicnumerals">
           <td>eastern arabic numerals</td>
+
           <td class="rtlTermCell">الأرقام العربية المشرقية</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td>٠ ١ ٢ ٣ ٤ ٥ ٦ ٧ ٨ ٩</td>
         </tr>
+
         <tr id="def_ellipsis">
           <td>ellipsis</td>
+
           <td class="rtlTermCell">علامة القطع، القطع</td>
+
           <td class="rtlTermCell">سه‌نقطه</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_EM">
           <td>EM</td>
+
           <td class="rtlTermCell">(وحدة قياس) إم، وحدة قياس النقطة</td>
+
           <td class="rtlTermCell">اِم، ضربه</td>
-          <td>Unit in the field of typography, equal to the currently specified point size. A
-          reference to the width of the capital "M"</td>
+
+          <td>Unit in the field of typography, equal to the currently specified
+          point size. A reference to the width of the capital "M"</td>
         </tr>
+
         <tr id="def_emdash">
           <td>em dash</td>
+
           <td class="rtlTermCell">خط فاصل من حجم ام، وصلة طويلة</td>
+
           <td class="rtlTermCell">خط</td>
+
           <td>A wide dash, usually of size EM</td>
         </tr>
+
         <tr id="def_emspace">
           <td>em space</td>
+
           <td class="rtlTermCell">مسافة من حجم ام، مسافة طويلة</td>
+
           <td class="rtlTermCell">فاصلهٔ اِم</td>
+
           <td>A wide space, usually of size EM</td>
         </tr>
+
         <tr id="def_EN">
           <td>EN</td>
+
           <td class="rtlTermCell">نصف وحدة قياس النقطة</td>
+
           <td class="rtlTermCell">اِن</td>
+
           <td>???</td>
         </tr>
+
         <tr id="def_endash">
           <td>en dash</td>
+
           <td class="rtlTermCell">وصلة متوسطة</td>
+
           <td class="rtlTermCell">خط اِن</td>
+
           <td>A not-so-wide dash, usually of size EN</td>
         </tr>
+
         <tr id="def_enspace">
           <td>en space</td>
+
           <td class="rtlTermCell">مسافة متوسطة</td>
+
           <td class="rtlTermCell">فاصلهٔ اِن</td>
+
           <td>A not-so-wide space, usually of size EN</td>
         </tr>
+
         <tr id="def_encoding">
           <td>encoding</td>
+
           <td class="rtlTermCell">ترميز</td>
+
           <td class="rtlTermCell">کدنگاری</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_endnote">
           <td>endnote</td>
+
           <td class="rtlTermCell">التعليق الختامي، حاشية</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A set of notes placed at the end of a part, chapter, section, paragraph and so on, or
-          at the end of a book.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A set of notes placed at the end of a part, chapter, section,
+          paragraph and so on, or at the end of a book.</td>
         </tr>
+
         <tr id="def_epigraph">
           <td>epigraph</td>
+
           <td class="rtlTermCell">كتابة منقوشة، اقتباس</td>
+
           <td class="rtlTermCell">سرلوحه</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_Europeannumerals">
           <td>European numerals</td>
-          <td class="rtlTermCell">الأرقام العربية الأوروبية، الأرقام العربية المغربية</td>
+
+          <td class="rtlTermCell">الأرقام العربية الأوروبية، الأرقام العربية
+          المغربية</td>
+
           <td class="rtlTermCell">ارقام اروپایی</td>
-          <td>Any of the symbols in [0-9] used to represent numbers. Sometimes called Arabic
-          numerals or ASCII numerals.</td>
+
+          <td>Any of the symbols in [0-9] used to represent numbers. Sometimes
+          called Arabic numerals or ASCII numerals.</td>
         </tr>
+
         <tr id="def_exceptiondictionary">
           <td>exception dictionary</td>
+
           <td class="rtlTermCell">قاموس استثناءات</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_exclamationmarks">
           <td>exclamation marks</td>
+
           <td class="rtlTermCell">علامة تعجب</td>
+
           <td class="rtlTermCell">علامت تعجب</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_figure">
           <td>figure</td>
+
           <td class="rtlTermCell">شكل</td>
+
           <td class="rtlTermCell">تصویر</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_first-lineindent">
           <td>first-line indent</td>
+
           <td class="rtlTermCell">مسافة السطر الأول</td>
+
           <td class="rtlTermCell">تورفتگی خط اول</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_fixed-width">
           <td>fixed-width</td>
+
           <td class="rtlTermCell">ثابت العرض</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A characteristic of a font where the same character advance is assigned for all
-          glyphs.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A characteristic of a font where the same character advance is
+          assigned for all glyphs.</td>
         </tr>
+
         <tr id="def_flushleftalignment">
           <td>flush left alignment</td>
+
           <td class="rtlTermCell">محاذاة إلى اليمين</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_flushrightalignment">
           <td>flush right alignment</td>
+
           <td class="rtlTermCell">محاذاة إلى اليسار</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_folio">
           <td>folio</td>
+
           <td class="rtlTermCell">ورقة، صفحة</td>
+
           <td class="rtlTermCell">شمارهٔ صفحه</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_font">
           <td>font</td>
+
           <td class="rtlTermCell">الخط</td>
+
           <td class="rtlTermCell">فونت، قلم</td>
+
           <td>A set of character glyphs of a given typeface.</td>
         </tr>
+
         <tr id="def_fontfamily/typefacefamily">
           <td>font family/typeface family</td>
+
           <td class="rtlTermCell">عائلة خطوط</td>
+
           <td class="rtlTermCell">خانوادهٔ فونت</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_fontmetrics">
           <td>font metrics</td>
+
           <td class="rtlTermCell">مقاييس الخط</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_foot">
           <td>foot</td>
+
           <td class="rtlTermCell">تذييل</td>
+
           <td class="rtlTermCell">پایه</td>
-          <td>a) The bottom part of a book or a page. b) The bottom margin between the edge of a
-          trimmed page and the hanmen (text area)</td>
+
+          <td>a) The bottom part of a book or a page. b) The bottom margin
+          between the edge of a trimmed page and the hanmen (text area)</td>
         </tr>
+
         <tr id="def_foot/bottommargin">
           <td>foot/bottom margin</td>
+
           <td class="rtlTermCell">الهامش الأسفل</td>
+
           <td class="rtlTermCell">حاشیهٔ پایینی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_footer">
           <td>footer</td>
+
           <td class="rtlTermCell">تذييل الصفحة</td>
+
           <td class="rtlTermCell">پاصفحه</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_footnote">
           <td>footnote</td>
+
           <td class="rtlTermCell">حاشية سفلية</td>
+
           <td class="rtlTermCell">پانویس</td>
-          <td>A note in a smaller face than that of main text, placed at the bottom of a page.</td>
+
+          <td>A note in a smaller face than that of main text, placed at the
+          bottom of a page.</td>
         </tr>
+
         <tr id="def_fore-edge">
           <td>fore-edge</td>
+
           <td class="rtlTermCell">الحافة العمودية الخارجية</td>
+
           <td class="rtlTermCell">حاشیهٔ بیرونی</td>
-          <td>a) The three front trimmed edges of pages in a book. b) The opposite sides of the
-          gutter in a book.</td>
+
+          <td>a) The three front trimmed edges of pages in a book. b) The
+          opposite sides of the gutter in a book.</td>
         </tr>
+
         <tr id="def_format">
           <td>format</td>
+
           <td class="rtlTermCell">تنسيق، هيئة</td>
+
           <td class="rtlTermCell">شکل‌بندی، شکل</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_fraction">
           <td>fraction</td>
+
           <td class="rtlTermCell">كسر</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_frontmatter">
           <td>front matter</td>
+
           <td class="rtlTermCell">المادة الأمامية</td>
+
           <td class="rtlTermCell">واحدهای پیش از متن</td>
-          <td>The first part of a book followed by the text, usually consisting of a forward,
-          preface, table of contents, list of illustrations, acknowledgement and so on.</td>
+
+          <td>The first part of a book followed by the text, usually consisting
+          of a forward, preface, table of contents, list of illustrations,
+          acknowledgement and so on.</td>
         </tr>
+
         <tr id="def_full-width">
           <td>full-width</td>
+
           <td class="rtlTermCell">تام العرض</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>a) Relative index for the length which is equal to a given character size. b)
-          Character frame which character advance is equal to the amount referred to as a). A
-          full-width character frame is square in shape by definition.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>a) Relative index for the length which is equal to a given
+          character size. b) Character frame which character advance is equal
+          to the amount referred to as a). A full-width character frame is
+          square in shape by definition.</td>
         </tr>
+
         <tr id="def_glyph">
           <td>glyph</td>
+
           <td class="rtlTermCell">محرف</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_goldenrectangle">
           <td>golden rectangle</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td class="rtlTermCell">مستطیل طلایی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_goldensection">
           <td>golden section</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td class="rtlTermCell">بخش طلایی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_Greekletters">
           <td>Greek letters</td>
+
           <td class="rtlTermCell">حروف يونانية</td>
+
           <td class="rtlTermCell">حروف یونانی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_gridalignment">
           <td>grid alignment</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td class="rtlTermCell">هم‌ترازی شطرنجی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_gutter">
           <td>gutter</td>
+
           <td class="rtlTermCell">حاشیه</td>
+
           <td class="rtlTermCell">حاشیه</td>
-          <td>a) The binding side of a spread of a book. b) the margin between the binding edge of
-          a book and the hanmen (text area). c) The part of a book where all pages are bound
-          together to the book spine.</td>
+
+          <td>a) The binding side of a spread of a book. b) the margin between
+          the binding edge of a book and the hanmen (text area). c) The part of
+          a book where all pages are bound together to the book spine.</td>
         </tr>
+
         <tr id="def_halfem">
           <td>half em</td>
+
           <td class="rtlTermCell">نصف ام</td>
+
           <td class="rtlTermCell">نیم اِم</td>
+
           <td>Half of the full-width size.</td>
         </tr>
+
         <tr id="def_halfemspace">
           <td>half em space</td>
+
           <td class="rtlTermCell">مسافة نصف اِم</td>
+
           <td class="rtlTermCell">فاصلهٔ نیم اِم</td>
+
           <td>Amount of space that is half size of em space.</td>
         </tr>
+
         <tr id="def_hangline">
           <td>hang line</td>
+
           <td class="rtlTermCell">سطر معلق</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_hangingindentation">
           <td>hanging indentation</td>
+
           <td class="rtlTermCell">تعليق المسافة البادئة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_hangingpunctuation">
           <td>hanging punctuation</td>
+
           <td class="rtlTermCell">تعليق علامات الترقيم</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_head">
           <td>head</td>
+
           <td class="rtlTermCell">رأس</td>
+
           <td class="rtlTermCell">سَر</td>
-          <td>a) The top part of a book or a page. b) The top margin between the top edge of a
-          trimmed page and the hanmen (text area)</td>
+
+          <td>a) The top part of a book or a page. b) The top margin between
+          the top edge of a trimmed page and the hanmen (text area)</td>
         </tr>
+
         <tr id="def_head/topmargin">
           <td>head/top margin</td>
+
           <td class="rtlTermCell">هامش علوي</td>
+
           <td class="rtlTermCell">حاشیهٔ بالا</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_header">
           <td>header</td>
+
           <td class="rtlTermCell">رأس</td>
+
           <td class="rtlTermCell">سرصفحه</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_heading">
           <td>heading</td>
+
           <td class="rtlTermCell">عنوان</td>
+
           <td class="rtlTermCell">عنوان</td>
-          <td>a) A title of a paper or an article. b) A title for each section of a book, paper or
-          article.</td>
+
+          <td>a) A title of a paper or an article. b) A title for each section
+          of a book, paper or article.</td>
         </tr>
+
         <tr id="def_headline">
           <td>headline</td>
+
           <td class="rtlTermCell">عنوان رئيسي</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_headnote">
           <td>headnote</td>
+
           <td class="rtlTermCell">تقدمة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A kind of notes in vertical writing style, head area in kihon-hanmen is kept
-          beforehand, and notes are set with smaller size font than main text.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A kind of notes in vertical writing style, head area in
+          kihon-hanmen is kept beforehand, and notes are set with smaller size
+          font than main text.</td>
         </tr>
+
         <tr id="def_hierarchy">
           <td>hierarchy</td>
+
           <td class="rtlTermCell">تسلسل هرمي، ترتيب هرمي</td>
+
           <td class="rtlTermCell">سلسله‌مراتب</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_horizontalwritingmode">
           <td>horizontal writing mode</td>
+
           <td class="rtlTermCell">صيغة الكتابة الأفقية</td>
+
           <td class="rtlTermCell">حالت نوشتار افقی</td>
-          <td>The process or the result of arranging characters on a line from left to right, of
-          lines on a page from top to bottom, and/or of columns on a page from left to right.</td>
+
+          <td>The process or the result of arranging characters on a line from
+          left to right, of lines on a page from top to bottom, and/or of
+          columns on a page from left to right.</td>
         </tr>
+
         <tr id="def_hyphen">
           <td>hyphen</td>
+
           <td class="rtlTermCell">واصلة</td>
+
           <td class="rtlTermCell">نیمخط</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_hyphenation">
           <td>hyphenation</td>
+
           <td class="rtlTermCell">واصلة، المقطعيّة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A method of breaking a line by dividing a Western word at the end of a line and
-          adding a hyphen at the end of the first half of the syllable.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A method of breaking a line by dividing a Western word at the end
+          of a line and adding a hyphen at the end of the first half of the
+          syllable.</td>
         </tr>
+
         <tr id="def_hyphenationandjustification">
           <td>hyphenation and justification</td>
+
           <td class="rtlTermCell">الواصلة والمحاذاة</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td>Also abbreviated as H&amp;J</td>
         </tr>
+
         <tr id="def_hyphenationroutine">
           <td>hyphenation routine</td>
+
           <td class="rtlTermCell">إجراء الواصلة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_illustrations">
           <td>illustrations</td>
+
           <td class="rtlTermCell">توضيح، رسم توضيحي، صورة إيضاحيّة</td>
+
           <td class="rtlTermCell">تصویر</td>
-          <td>A general term referring to a diagram, chart, cut, figure, picture and the like, to
-          be used for printed materials.</td>
+
+          <td>A general term referring to a diagram, chart, cut, figure,
+          picture and the like, to be used for printed materials.</td>
         </tr>
+
         <tr id="def_indentation">
           <td>indentation</td>
+
           <td class="rtlTermCell">إزاحة، مسافة بادئة</td>
+
           <td class="rtlTermCell">فاصلهٔ سرِ سطر، تورفتگی سرِ سطر</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_independentpagination">
           <td>independent pagination</td>
+
           <td class="rtlTermCell">ترقيم الصفحات مستقل</td>
+
           <td class="rtlTermCell">صفحه‌بندی مستقل</td>
-          <td>To number the pages of the front matter, the text and the back matter
-          independently.</td>
+
+          <td>To number the pages of the front matter, the text and the back
+          matter independently.</td>
         </tr>
+
         <tr id="def_index">
           <td>index</td>
+
           <td class="rtlTermCell">فهرس</td>
+
           <td class="rtlTermCell">فهرست راهنما</td>
-          <td>A list of terms or subjects with page numbers for where they are referred to in a
-          single or multiple volumes of a book.</td>
+
+          <td>A list of terms or subjects with page numbers for where they are
+          referred to in a single or multiple volumes of a book.</td>
         </tr>
+
         <tr id="def_initial">
           <td>initial</td>
+
           <td class="rtlTermCell">أولي</td>
+
           <td class="rtlTermCell">آغازین</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_inlinedirection">
           <td>inline direction</td>
+
           <td class="rtlTermCell">الاتجاه السطري</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td>Text direction in a line.</td>
         </tr>
+
         <tr id="def_input">
           <td>input</td>
+
           <td class="rtlTermCell">إدخال</td>
+
           <td class="rtlTermCell">ورودی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_inseparablecharactersrule">
           <td>inseparable characters rule</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A line adjustment rule that prohibits inserting any space between specific
-          combinations of characters.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A line adjustment rule that prohibits inserting any space between
+          specific combinations of characters.</td>
         </tr>
+
         <tr id="def_interpunct">
           <td>interpunct</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_italics">
           <td>italics</td>
+
           <td class="rtlTermCell">مائل</td>
+
           <td class="rtlTermCell">ایتالیک</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_itemization">
           <td>itemization</td>
+
           <td class="rtlTermCell">وضع بنود، تبويب، عناصر</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td>To list ordered or unordered items one under the other.</td>
         </tr>
+
         <tr id="def_justifiedalignment">
           <td>justified alignment</td>
+
           <td class="rtlTermCell">محاذاة على الجانبين، مساواة</td>
+
           <td class="rtlTermCell">هم‌ترازی میزان</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_kashida">
           <td>kashida</td>
+
           <td class="rtlTermCell">الكشيدة، التطويل</td>
+
           <td class="rtlTermCell">کشیده</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_labelname">
           <td>label name</td>
+
           <td class="rtlTermCell">اسم بطاقة العنونة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>Text following or followed by numbers for illustrations, tables, headings and running
-          headings.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>Text following or followed by numbers for illustrations, tables,
+          headings and running headings.</td>
         </tr>
+
         <tr id="def_Latinletters">
           <td>Latin letters</td>
+
           <td class="rtlTermCell">حروف لاتينية</td>
+
           <td class="rtlTermCell">حروف لاتین</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_layout">
           <td>layout</td>
+
           <td class="rtlTermCell">نسق، تصميم</td>
+
           <td class="rtlTermCell">قالب‌بندی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_leading">
           <td>leading</td>
+
           <td class="rtlTermCell">قيادي</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_letterface">
           <td>letter face</td>
+
           <td class="rtlTermCell">صورة الحرف</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td>Area in which glyph is drawn.</td>
         </tr>
+
         <tr id="def_lettering">
           <td>lettering</td>
+
           <td class="rtlTermCell">ترقين، كتابة</td>
+
           <td class="rtlTermCell">طراحی حروف</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_letterpressprinting">
           <td>letterpress printing</td>
+
           <td class="rtlTermCell">طباعة الحروف</td>
+
           <td class="rtlTermCell">چاپ برجسته</td>
+
           <td>The traditional printing method using movable type.</td>
         </tr>
+
         <tr id="def_letterspacing">
           <td>letterspacing</td>
+
           <td class="rtlTermCell">تباعد الحروف</td>
+
           <td class="rtlTermCell">فاصلهٔ حروف</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_ligature">
           <td>ligature</td>
+
           <td class="rtlTermCell">ضمد</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_line">
           <td>line</td>
+
           <td class="rtlTermCell">سطر</td>
+
           <td class="rtlTermCell">خط</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_lineadjustment">
           <td>line adjustment</td>
+
           <td class="rtlTermCell">محاذاة السطر</td>
+
           <td class="rtlTermCell">تنظیم خط</td>
-          <td>A method of aligning both edges of all lines to be the same given length by removing
-          or adding adjustable spaces.</td>
+
+          <td>A method of aligning both edges of all lines to be the same given
+          length by removing or adding adjustable spaces.</td>
         </tr>
+
         <tr id="def_lineadjustmentbyhangingpunctuation">
           <td>line adjustment by hanging punctuation</td>
+
           <td class="rtlTermCell">محاذاة السطر بتعليق علامات الترقيم</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A line breaking rule to avoid commas or full stops at a line head (which is
-          prohibited in Japanese typography) by taking them back to the end of the previous line
-          beyond the specified line length.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A line breaking rule to avoid commas or full stops at a line head
+          (which is prohibited in Japanese typography) by taking them back to
+          the end of the previous line beyond the specified line length.</td>
         </tr>
+
         <tr id="def_lineadjustmentbyinter-characterspaceexpansion">
           <td>line adjustment by inter-character space expansion</td>
+
           <td class="rtlTermCell">محاذاة السطر بتوسيع مساحة بين المحارف</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A line breaking rule that aligns both edges of a line by expanding inter-character
-          spaces. .</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A line breaking rule that aligns both edges of a line by
+          expanding inter-character spaces. .</td>
         </tr>
+
         <tr id="def_linebreakingrules">
           <td>line breaking rules</td>
+
           <td class="rtlTermCell">قواعد كسر السطر</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A set of rules to avoid prohibited layout in Japanese typography, such as "line-start
-          prohibition rule", "line-end prohibition rule", inseparable or unbreakable character
-          sequences and so on.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A set of rules to avoid prohibited layout in Japanese typography,
+          such as "line-start prohibition rule", "line-end prohibition rule",
+          inseparable or unbreakable character sequences and so on.</td>
         </tr>
+
         <tr id="def_lineend">
           <td>line end</td>
+
           <td class="rtlTermCell">نهاية السطر</td>
+
           <td class="rtlTermCell">انتهای خط</td>
+
           <td>The position at which a line ends.</td>
         </tr>
+
         <tr id="def_lineendalignment">
           <td>line end alignment</td>
+
           <td class="rtlTermCell">محاذاة نهاية السطر</td>
+
           <td class="rtlTermCell">هم‌ترازی انتهای خط</td>
+
           <td>To align a run of text to the line end.</td>
         </tr>
+
         <tr id="def_lineendindent">
           <td>line end indent</td>
+
           <td class="rtlTermCell">مسافة بدئ نهاية السطر</td>
+
           <td class="rtlTermCell">تورفتگی انتهای خط</td>
-          <td>To reserve a certain amount of space before the default position of a line end.</td>
+
+          <td>To reserve a certain amount of space before the default position
+          of a line end.</td>
         </tr>
+
         <tr id="def_linefeed">
           <td>line feed</td>
+
           <td class="rtlTermCell">تغذية السطر</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>The distance between two adjacent lines measured by their reference points.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>The distance between two adjacent lines measured by their
+          reference points.</td>
         </tr>
+
         <tr id="def_linegap">
           <td>line gap</td>
+
           <td class="rtlTermCell">فجوة السطر</td>
+
           <td class="rtlTermCell">فاصلهٔ بین خطوط</td>
+
           <td>The smallest amount of space between adjacent lines.</td>
         </tr>
+
         <tr id="def_linehead">
           <td>line head</td>
+
           <td class="rtlTermCell">رأس السطر</td>
+
           <td class="rtlTermCell">سرِ سطر</td>
+
           <td>The position at which a line starts.</td>
         </tr>
+
         <tr id="def_lineheadalignment">
           <td>line head alignment</td>
+
           <td class="rtlTermCell">محاذاة رأس السطر</td>
+
           <td class="rtlTermCell">هم‌ترازیِ سر سطر</td>
+
           <td>To align a run of text to the line head.</td>
         </tr>
+
         <tr id="def_lineheadindent">
           <td>line head indent</td>
+
           <td class="rtlTermCell">مسافة بدئ راس السطر</td>
+
           <td class="rtlTermCell">فاصلهٔ سر سطر، تو رفتگی سر سطر</td>
-          <td>To reserve a certain amount of space after the default position of a line head.</td>
+
+          <td>To reserve a certain amount of space after the default position
+          of a line head.</td>
         </tr>
+
         <tr id="def_lineheight">
           <td>line height</td>
+
           <td class="rtlTermCell">ارتفاع الخط</td>
+
           <td class="rtlTermCell">ارتفاع خط</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_linelength">
           <td>line length</td>
+
           <td class="rtlTermCell">طول السطر</td>
+
           <td class="rtlTermCell">طول خط</td>
-          <td>Length of a line with a pre-defined number of characters. When the line is indented
-          at the line head or the line end, it is length of the line from the specified amount of
-          line head indent to the specified amount of line end indent.</td>
+
+          <td>Length of a line with a pre-defined number of characters. When
+          the line is indented at the line head or the line end, it is length
+          of the line from the specified amount of line head indent to the
+          specified amount of line end indent.</td>
         </tr>
+
         <tr id="def_linespacing">
           <td>line spacing</td>
+
           <td class="rtlTermCell">تباعد الأسطر</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_line-endprohibitionrule">
           <td>line-end prohibition rule</td>
+
           <td class="rtlTermCell">قاعدة حظر نهاية السطر</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A line breaking rule that prohibits specific characters at a line end.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A line breaking rule that prohibits specific characters at a line
+          end.</td>
         </tr>
+
         <tr id="def_line-startprohibitionrule">
           <td>line-start prohibition rule</td>
+
           <td class="rtlTermCell">قاعدة حظر بداية السطر</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A line breaking rule that prohibits specific characters at a line head.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A line breaking rule that prohibits specific characters at a line
+          head.</td>
         </tr>
+
         <tr id="def_list">
           <td>list</td>
+
           <td class="rtlTermCell">قائمة، لائحة</td>
+
           <td class="rtlTermCell">فهرست</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_longdash">
           <td>long dash</td>
+
           <td class="rtlTermCell">شرطة طويلة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_maintext">
           <td>main text</td>
+
           <td class="rtlTermCell">نص رئيسي</td>
+
           <td class="rtlTermCell">متن اصلی</td>
-          <td>a) The principal part of a book, usually preceded by the front matter, followed by
-          the back matter. b) The principal part of an article excluding figures, tables, heading,
-          notes, leads and so on. c) The content of a page excluding running heads and page
-          numbers. d) The net contents of a book excluding covers, end papers, insets and so
-          on.</td>
-        </tr>
-        <tr id="def_margin">
-          <td>margin</td>
-          <td class="rtlTermCell">هامش</td>
-          <td class="rtlTermCell">حاشیه</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_measure">
-          <td>measure</td>
-          <td class="rtlTermCell">قياس</td>
-          <td class="rtlTermCell">مقیاس، اندازه</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_measurement">
-          <td>measurement</td>
-          <td class="rtlTermCell">قياس</td>
-          <td class="rtlTermCell">اندازه‌گیری</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_mixedtextcomposition">
-          <td>mixed text composition</td>
-          <td class="rtlTermCell">تركيبة النص المختلِط</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>a) To interleave Japanese text with Western text in a line (Japanese and Western
-          mixed text composition). b) To compose text with different sizes of characters (mixed
-          size composition). c) To compose text with different typefaces (mixed typeface
-          composition).</td>
-        </tr>
-        <tr id="def_mixingtypefaces">
-          <td>mixing typefaces</td>
-          <td class="rtlTermCell">خلط أنماط الخطوط</td>
-          <td class="rtlTermCell">ترکیب قلم‌ها</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_modulargrid">
-          <td>modular grid</td>
-          <td class="rtlTermCell">شبكة وحدات، شبكة مركبة من وحدات</td>
-          <td class="rtlTermCell">شطرنجی مُدولی</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_multi-columnformat">
-          <td>multi-column format</td>
-          <td class="rtlTermCell">تنسيق متعدد الأعمدة</td>
-          <td class="rtlTermCell">شکل‌بندی چندستونی</td>
-          <td>A format of text on a page where text is divided into two or more sections (columns)
-          in the inline direction and each column is separated by a certain amount of space (column
-          space).</td>
-        </tr>
-        <tr id="def_multi-columngrid">
-          <td>multi-column grid</td>
-          <td class="rtlTermCell">شبكة متعددة الأعمدة</td>
-          <td class="rtlTermCell">شطرنجی چندستونی</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_multivolumework">
-          <td>multivolume work</td>
-          <td class="rtlTermCell">عمل متعدد الأجزاء</td>
-          <td class="rtlTermCell">اثر چند جلدی</td>
-          <td>A set of work published in two or more volumes, as in the complete work or the
-          first/last half volumes.</td>
-        </tr>
-        <tr id="def_newcolumn">
-          <td>new column</td>
-          <td class="rtlTermCell">عمود جديد</td>
-          <td class="rtlTermCell">ستون جدید</td>
-          <td>In multi-column setting, to change to new column before the end of current
-          column.</td>
-        </tr>
-        <tr id="def_newrecto">
-          <td>new recto</td>
-          <td class="rtlTermCell">صفحة يمنى جديدة</td>
-          <td class="rtlTermCell">آغاز در صفحهٔ فرد</td>
-          <td>To start a new heading or something on a odd page.</td>
-        </tr>
-        <tr id="def_no-breaktext">
-          <td>no-break text</td>
-          <td class="rtlTermCell">عدم تفكُّك النص، نص دون اِنفِكاك</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_nonbreakinghyphen">
-          <td>nonbreaking hyphen</td>
-          <td class="rtlTermCell">واصلة غير منقسمة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_nonbreakingwordspace">
-          <td>nonbreaking word space</td>
-          <td class="rtlTermCell">فضاء كلمة غير منقسمة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_note">
-          <td>note</td>
-          <td class="rtlTermCell">ملاحظة</td>
-          <td class="rtlTermCell">یادداشت</td>
-          <td>Explanatory information added to terms, figures or tables.</td>
-        </tr>
-        <tr id="def_numberofcharactersperline">
-          <td>number of characters per line</td>
-          <td class="rtlTermCell">عدد الأحرف في كل سطر</td>
-          <td class="rtlTermCell">تعداد حروف در خط</td>
-          <td>Number of characters in a line to specify the length of lines.</td>
-        </tr>
-        <tr id="def_numberofcolumns">
-          <td>number of columns</td>
-          <td class="rtlTermCell">عدد الأعمدة</td>
-          <td class="rtlTermCell">تعداد ستون‌ها</td>
-          <td>Number of columns on a page.</td>
-        </tr>
-        <tr id="def_numerals">
-          <td>numerals</td>
-          <td class="rtlTermCell">الأعداد</td>
-          <td class="rtlTermCell">اعداد</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_oneemspace">
-          <td>one em space</td>
-          <td class="rtlTermCell">مسافة اِم واحدة</td>
-          <td class="rtlTermCell">فاصلهٔ اِم</td>
-          <td>Amount of space that is full-width size.</td>
-        </tr>
-        <tr id="def_onethirdem">
-          <td>one third em</td>
-          <td class="rtlTermCell">ثلث اِم</td>
-          <td class="rtlTermCell">یک‌سوم اِم</td>
-          <td>One third of the full-width size.</td>
-        </tr>
-        <tr id="def_onethirdemspace">
-          <td>one third em space</td>
-          <td class="rtlTermCell">مسافة ثلث اِم</td>
-          <td class="rtlTermCell">فاصلهٔ یک‌سوم اِم</td>
-          <td>Amount of space that is one third size of em space.</td>
-        </tr>
-        <tr id="def_openingbrackets">
-          <td>opening brackets</td>
-          <td class="rtlTermCell">فتح قوسين</td>
-          <td class="rtlTermCell">کروشه باز</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_opticalsize">
-          <td>optical size</td>
-          <td class="rtlTermCell">حجم بصري</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_opticalspacing">
-          <td>optical spacing</td>
-          <td class="rtlTermCell">تباعد بصري</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_orientation">
-          <td>orientation</td>
-          <td class="rtlTermCell">اتجاه</td>
-          <td class="rtlTermCell">جهت</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_ornament">
-          <td>ornament</td>
-          <td class="rtlTermCell">زخرفة</td>
-          <td class="rtlTermCell">تزئینی</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_outdent">
-          <td>outdent</td>
-          <td class="rtlTermCell">إلغاء التأخير، إلغاء الإزاحة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_overhang">
-          <td>overhang</td>
-          <td class="rtlTermCell">عبء</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_overrun">
-          <td>overrun</td>
-          <td class="rtlTermCell">تجاوز، اجتياح</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_page">
-          <td>page</td>
-          <td class="rtlTermCell">صفحة</td>
-          <td class="rtlTermCell">صفحه</td>
-          <td>A side of a sheet of paper in a written work such as a book.</td>
-        </tr>
-        <tr id="def_pagebreak">
-          <td>page break</td>
-          <td class="rtlTermCell">فاصل صفحة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>To end a page even if it is not full and to start a new page with the next paragraph,
-          a new heading and so on.</td>
-        </tr>
-        <tr id="def_pageformat">
-          <td>page format</td>
-          <td class="rtlTermCell">شكل الصفحة</td>
-          <td class="rtlTermCell">شکل‌بندی صفحه</td>
-          <td>The layout and presentation of a page with text, graphics and other elements for a
-          publication such as a book.</td>
-        </tr>
-        <tr id="def_pagenumber">
-          <td>page number</td>
-          <td class="rtlTermCell">رقم الصفحة</td>
-          <td class="rtlTermCell">شمارهٔ صفحه</td>
-          <td>A sequential number to indicate the order of pages in a publication.</td>
-        </tr>
-        <tr id="def_pagination">
-          <td>pagination</td>
-          <td class="rtlTermCell">ترقيم الصفحات</td>
-          <td class="rtlTermCell">صفحه‌شماری</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_paragraph">
-          <td>paragraph</td>
-          <td class="rtlTermCell">فقرة</td>
-          <td class="rtlTermCell">پاراگراف</td>
-          <td>A group of sentences to be processed for line composition. A paragraph consists of
-          one or more lines.</td>
-        </tr>
-        <tr id="def_paragraphbreak">
-          <td>paragraph break</td>
-          <td class="rtlTermCell">كسر الفقرة</td>
-          <td class="rtlTermCell">شکستن پاراگراف</td>
-          <td>To start a new line to indicate a new paragraph.</td>
-        </tr>
-        <tr id="def_paragraphformat">
-          <td>paragraph format</td>
-          <td class="rtlTermCell">تنسيق الفقرة</td>
-          <td class="rtlTermCell">شکل‌بندی پاراگراف</td>
-          <td>A format of a paragraph, as in line head indent or line end indent.</td>
-        </tr>
-        <tr id="def_paragraphindent">
-          <td>paragraph indent</td>
-          <td class="rtlTermCell">هامش الفقرة، المسافة البادئة للفقرة</td>
-          <td class="rtlTermCell">تورفتگی پاراگراف</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_parenthesis">
-          <td>parenthesis</td>
-          <td class="rtlTermCell">أقواس</td>
-          <td class="rtlTermCell">پرانتز</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_period">
-          <td>period</td>
-          <td class="rtlTermCell">نقطه</td>
-          <td class="rtlTermCell">نقطه</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_pixel">
-          <td>pixel</td>
-          <td class="rtlTermCell">بكسل، بيكسل</td>
-          <td class="rtlTermCell">پیکسل</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_point">
-          <td>point</td>
-          <td class="rtlTermCell">نقطة</td>
-          <td class="rtlTermCell">نقطه</td>
-          <td>A measurement unit of character size. 1 point is equal to 0.3514mm (see JIS Z 8305).
-          There is another unit to measure character sizes called Q, where 1Q is equivalent to
-          0.25mm.</td>
-        </tr>
-        <tr id="def_polyglot">
-          <td>polyglot</td>
-          <td class="rtlTermCell">متعدد اللغات</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_printingtypes">
-          <td>printing types</td>
-          <td class="rtlTermCell">أنواع الطباعة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>Movable type used for letterpress printing.</td>
-        </tr>
-        <tr id="def_proportional">
-          <td>proportional</td>
-          <td class="rtlTermCell">متناسب</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A characteristic of a font where character advance is different per glyph.</td>
-        </tr>
-        <tr id="def_proportionalfonts">
-          <td>proportional fonts</td>
-          <td class="rtlTermCell">الخطوط المتناسبة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
-        </tr>
-        <tr id="def_punctuationmarks">
-          <td>punctuation marks</td>
-          <td class="rtlTermCell">علامات الترقيم</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A general term referring to the symbols used in text composition to help make the
-          meaning of text clearer, as in commas, full stops, question marks, brackets, diereses and
+
+          <td>a) The principal part of a book, usually preceded by the front
+          matter, followed by the back matter. b) The principal part of an
+          article excluding figures, tables, heading, notes, leads and so on.
+          c) The content of a page excluding running heads and page numbers. d)
+          The net contents of a book excluding covers, end papers, insets and
           so on.</td>
         </tr>
+
+        <tr id="def_margin">
+          <td>margin</td>
+
+          <td class="rtlTermCell">هامش</td>
+
+          <td class="rtlTermCell">حاشیه</td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_measure">
+          <td>measure</td>
+
+          <td class="rtlTermCell">قياس</td>
+
+          <td class="rtlTermCell">مقیاس، اندازه</td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_measurement">
+          <td>measurement</td>
+
+          <td class="rtlTermCell">قياس</td>
+
+          <td class="rtlTermCell">اندازه‌گیری</td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_mixedtextcomposition">
+          <td>mixed text composition</td>
+
+          <td class="rtlTermCell">تركيبة النص المختلِط</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>a) To interleave Japanese text with Western text in a line
+          (Japanese and Western mixed text composition). b) To compose text
+          with different sizes of characters (mixed size composition). c) To
+          compose text with different typefaces (mixed typeface
+          composition).</td>
+        </tr>
+
+        <tr id="def_mixingtypefaces">
+          <td>mixing typefaces</td>
+
+          <td class="rtlTermCell">خلط أنماط الخطوط</td>
+
+          <td class="rtlTermCell">ترکیب قلم‌ها</td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_modulargrid">
+          <td>modular grid</td>
+
+          <td class="rtlTermCell">شبكة وحدات، شبكة مركبة من وحدات</td>
+
+          <td class="rtlTermCell">شطرنجی مُدولی</td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_multi-columnformat">
+          <td>multi-column format</td>
+
+          <td class="rtlTermCell">تنسيق متعدد الأعمدة</td>
+
+          <td class="rtlTermCell">شکل‌بندی چندستونی</td>
+
+          <td>A format of text on a page where text is divided into two or more
+          sections (columns) in the inline direction and each column is
+          separated by a certain amount of space (column space).</td>
+        </tr>
+
+        <tr id="def_multi-columngrid">
+          <td>multi-column grid</td>
+
+          <td class="rtlTermCell">شبكة متعددة الأعمدة</td>
+
+          <td class="rtlTermCell">شطرنجی چندستونی</td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_multivolumework">
+          <td>multivolume work</td>
+
+          <td class="rtlTermCell">عمل متعدد الأجزاء</td>
+
+          <td class="rtlTermCell">اثر چند جلدی</td>
+
+          <td>A set of work published in two or more volumes, as in the
+          complete work or the first/last half volumes.</td>
+        </tr>
+
+        <tr id="def_newcolumn">
+          <td>new column</td>
+
+          <td class="rtlTermCell">عمود جديد</td>
+
+          <td class="rtlTermCell">ستون جدید</td>
+
+          <td>In multi-column setting, to change to new column before the end
+          of current column.</td>
+        </tr>
+
+        <tr id="def_newrecto">
+          <td>new recto</td>
+
+          <td class="rtlTermCell">صفحة يمنى جديدة</td>
+
+          <td class="rtlTermCell">آغاز در صفحهٔ فرد</td>
+
+          <td>To start a new heading or something on a odd page.</td>
+        </tr>
+
+        <tr id="def_no-breaktext">
+          <td>no-break text</td>
+
+          <td class="rtlTermCell">عدم تفكُّك النص، نص دون اِنفِكاك</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_nonbreakinghyphen">
+          <td>nonbreaking hyphen</td>
+
+          <td class="rtlTermCell">واصلة غير منقسمة</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_nonbreakingwordspace">
+          <td>nonbreaking word space</td>
+
+          <td class="rtlTermCell">فضاء كلمة غير منقسمة</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_note">
+          <td>note</td>
+
+          <td class="rtlTermCell">ملاحظة</td>
+
+          <td class="rtlTermCell">یادداشت</td>
+
+          <td>Explanatory information added to terms, figures or tables.</td>
+        </tr>
+
+        <tr id="def_numberofcharactersperline">
+          <td>number of characters per line</td>
+
+          <td class="rtlTermCell">عدد الأحرف في كل سطر</td>
+
+          <td class="rtlTermCell">تعداد حروف در خط</td>
+
+          <td>Number of characters in a line to specify the length of
+          lines.</td>
+        </tr>
+
+        <tr id="def_numberofcolumns">
+          <td>number of columns</td>
+
+          <td class="rtlTermCell">عدد الأعمدة</td>
+
+          <td class="rtlTermCell">تعداد ستون‌ها</td>
+
+          <td>Number of columns on a page.</td>
+        </tr>
+
+        <tr id="def_numerals">
+          <td>numerals</td>
+
+          <td class="rtlTermCell">الأعداد</td>
+
+          <td class="rtlTermCell">اعداد</td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_oneemspace">
+          <td>one em space</td>
+
+          <td class="rtlTermCell">مسافة اِم واحدة</td>
+
+          <td class="rtlTermCell">فاصلهٔ اِم</td>
+
+          <td>Amount of space that is full-width size.</td>
+        </tr>
+
+        <tr id="def_onethirdem">
+          <td>one third em</td>
+
+          <td class="rtlTermCell">ثلث اِم</td>
+
+          <td class="rtlTermCell">یک‌سوم اِم</td>
+
+          <td>One third of the full-width size.</td>
+        </tr>
+
+        <tr id="def_onethirdemspace">
+          <td>one third em space</td>
+
+          <td class="rtlTermCell">مسافة ثلث اِم</td>
+
+          <td class="rtlTermCell">فاصلهٔ یک‌سوم اِم</td>
+
+          <td>Amount of space that is one third size of em space.</td>
+        </tr>
+
+        <tr id="def_openingbrackets">
+          <td>opening brackets</td>
+
+          <td class="rtlTermCell">فتح قوسين</td>
+
+          <td class="rtlTermCell">کروشه باز</td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_opticalsize">
+          <td>optical size</td>
+
+          <td class="rtlTermCell">حجم بصري</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_opticalspacing">
+          <td>optical spacing</td>
+
+          <td class="rtlTermCell">تباعد بصري</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_orientation">
+          <td>orientation</td>
+
+          <td class="rtlTermCell">اتجاه</td>
+
+          <td class="rtlTermCell">جهت</td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_ornament">
+          <td>ornament</td>
+
+          <td class="rtlTermCell">زخرفة</td>
+
+          <td class="rtlTermCell">تزئینی</td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_outdent">
+          <td>outdent</td>
+
+          <td class="rtlTermCell">إلغاء التأخير، إلغاء الإزاحة</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_overhang">
+          <td>overhang</td>
+
+          <td class="rtlTermCell">عبء</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_overrun">
+          <td>overrun</td>
+
+          <td class="rtlTermCell">تجاوز، اجتياح</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_page">
+          <td>page</td>
+
+          <td class="rtlTermCell">صفحة</td>
+
+          <td class="rtlTermCell">صفحه</td>
+
+          <td>A side of a sheet of paper in a written work such as a book.</td>
+        </tr>
+
+        <tr id="def_pagebreak">
+          <td>page break</td>
+
+          <td class="rtlTermCell">فاصل صفحة</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>To end a page even if it is not full and to start a new page with
+          the next paragraph, a new heading and so on.</td>
+        </tr>
+
+        <tr id="def_pageformat">
+          <td>page format</td>
+
+          <td class="rtlTermCell">شكل الصفحة</td>
+
+          <td class="rtlTermCell">شکل‌بندی صفحه</td>
+
+          <td>The layout and presentation of a page with text, graphics and
+          other elements for a publication such as a book.</td>
+        </tr>
+
+        <tr id="def_pagenumber">
+          <td>page number</td>
+
+          <td class="rtlTermCell">رقم الصفحة</td>
+
+          <td class="rtlTermCell">شمارهٔ صفحه</td>
+
+          <td>A sequential number to indicate the order of pages in a
+          publication.</td>
+        </tr>
+
+        <tr id="def_pagination">
+          <td>pagination</td>
+
+          <td class="rtlTermCell">ترقيم الصفحات</td>
+
+          <td class="rtlTermCell">صفحه‌شماری</td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_paragraph">
+          <td>paragraph</td>
+
+          <td class="rtlTermCell">فقرة</td>
+
+          <td class="rtlTermCell">پاراگراف</td>
+
+          <td>A group of sentences to be processed for line composition. A
+          paragraph consists of one or more lines.</td>
+        </tr>
+
+        <tr id="def_paragraphbreak">
+          <td>paragraph break</td>
+
+          <td class="rtlTermCell">كسر الفقرة</td>
+
+          <td class="rtlTermCell">شکستن پاراگراف</td>
+
+          <td>To start a new line to indicate a new paragraph.</td>
+        </tr>
+
+        <tr id="def_paragraphformat">
+          <td>paragraph format</td>
+
+          <td class="rtlTermCell">تنسيق الفقرة</td>
+
+          <td class="rtlTermCell">شکل‌بندی پاراگراف</td>
+
+          <td>A format of a paragraph, as in line head indent or line end
+          indent.</td>
+        </tr>
+
+        <tr id="def_paragraphindent">
+          <td>paragraph indent</td>
+
+          <td class="rtlTermCell">هامش الفقرة، المسافة البادئة للفقرة</td>
+
+          <td class="rtlTermCell">تورفتگی پاراگراف</td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_parenthesis">
+          <td>parenthesis</td>
+
+          <td class="rtlTermCell">أقواس</td>
+
+          <td class="rtlTermCell">پرانتز</td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_period">
+          <td>period</td>
+
+          <td class="rtlTermCell">نقطه</td>
+
+          <td class="rtlTermCell">نقطه</td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_pixel">
+          <td>pixel</td>
+
+          <td class="rtlTermCell">بكسل، بيكسل</td>
+
+          <td class="rtlTermCell">پیکسل</td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_point">
+          <td>point</td>
+
+          <td class="rtlTermCell">نقطة</td>
+
+          <td class="rtlTermCell">نقطه</td>
+
+          <td>A measurement unit of character size. 1 point is equal to
+          0.3514mm (see JIS Z 8305). There is another unit to measure character
+          sizes called Q, where 1Q is equivalent to 0.25mm.</td>
+        </tr>
+
+        <tr id="def_polyglot">
+          <td>polyglot</td>
+
+          <td class="rtlTermCell">متعدد اللغات</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_printingtypes">
+          <td>printing types</td>
+
+          <td class="rtlTermCell">أنواع الطباعة</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>Movable type used for letterpress printing.</td>
+        </tr>
+
+        <tr id="def_proportional">
+          <td>proportional</td>
+
+          <td class="rtlTermCell">متناسب</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A characteristic of a font where character advance is different
+          per glyph.</td>
+        </tr>
+
+        <tr id="def_proportionalfonts">
+          <td>proportional fonts</td>
+
+          <td class="rtlTermCell">الخطوط المتناسبة</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
+        </tr>
+
+        <tr id="def_punctuationmarks">
+          <td>punctuation marks</td>
+
+          <td class="rtlTermCell">علامات الترقيم</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A general term referring to the symbols used in text composition
+          to help make the meaning of text clearer, as in commas, full stops,
+          question marks, brackets, diereses and so on.</td>
+        </tr>
+
         <tr id="def_quad">
           <td>quad</td>
+
           <td class="rtlTermCell">رباعية</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_quarterem">
           <td>quarter em</td>
+
           <td class="rtlTermCell">ربع اِم</td>
+
           <td class="rtlTermCell">رُبع اِم</td>
+
           <td>Quarter size of full-width.</td>
         </tr>
+
         <tr id="def_quarteremspace">
           <td>quarter em space</td>
+
           <td class="rtlTermCell">مساحة ربع اِم</td>
+
           <td class="rtlTermCell">فاصلهٔ رُبع اِم</td>
+
           <td>Amount of space that is a quarter of an em space in size.</td>
         </tr>
+
         <tr id="def_quarteremwidth">
           <td>quarter em width</td>
+
           <td class="rtlTermCell">عرض ربع اِم</td>
+
           <td class="rtlTermCell">پهنای رُبع اِم</td>
-          <td>Character frame which has a character advance of a quarter em.</td>
+
+          <td>Character frame which has a character advance of a quarter
+          em.</td>
         </tr>
+
         <tr id="def_questionmark">
           <td>question mark</td>
+
           <td class="rtlTermCell">علامة استفهام</td>
+
           <td class="rtlTermCell">علامت سوال</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_quotation">
           <td>quotation</td>
+
           <td class="rtlTermCell">اقتباس</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td>Excerps from other published works.</td>
         </tr>
+
         <tr id="def_rag">
           <td>rag</td>
+
           <td class="rtlTermCell">خرقة؟</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_referencemarks">
           <td>reference marks</td>
+
           <td class="rtlTermCell">العلامات المرجعية</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A symbol or short run of text attached to a specific part of text, to which notes are
-          provided followed by the corresponding marks.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A symbol or short run of text attached to a specific part of
+          text, to which notes are provided followed by the corresponding
+          marks.</td>
         </tr>
+
         <tr id="def_referencenumber">
           <td>reference number</td>
+
           <td class="rtlTermCell">الرقم المرجعي</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_reversepagination">
           <td>reverse pagination</td>
+
           <td class="rtlTermCell">ترقيم الصفحات عكسي</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td>Numbering pages of a book backwards.</td>
         </tr>
+
         <tr id="def_reversedtype">
           <td>reversed type</td>
+
           <td class="rtlTermCell">نوع عكس</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_river">
           <td>river</td>
+
           <td class="rtlTermCell">نهر</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_riverofwhite">
           <td>river of white</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_Romannumerals">
           <td>Roman numerals</td>
+
           <td class="rtlTermCell">الأرقام الرومانية</td>
+
           <td class="rtlTermCell">اعداد رومی</td>
-          <td>Numerals represented by upper case or lower case of Latin letters.</td>
+
+          <td>Numerals represented by upper case or lower case of Latin
+          letters.</td>
         </tr>
+
         <tr id="def_romanization">
           <td>romanization</td>
+
           <td class="rtlTermCell">الكتابة بالحروف اللاتينية</td>
+
           <td class="rtlTermCell">لاتین‌نویسی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_rule">
           <td>rule</td>
+
           <td class="rtlTermCell">قاعدة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_runback">
           <td>run back</td>
+
           <td class="rtlTermCell">تشغيل مرة أخرى</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_rundown">
           <td>run down</td>
+
           <td class="rtlTermCell">انقلب</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_runin">
           <td>run in</td>
+
           <td class="rtlTermCell">تشغيل في</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_run-inheading">
           <td>run-in heading</td>
+
           <td class="rtlTermCell">عنوان بدون انقطاع</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A kind of heading style to continue main text just after the heading without line
-          break.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A kind of heading style to continue main text just after the
+          heading without line break.</td>
         </tr>
+
         <tr id="def_runaround">
           <td>runaround</td>
+
           <td class="rtlTermCell">انسياب</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_runningfeet">
           <td>running feet</td>
+
           <td class="rtlTermCell">تشغيل أسفل؟؟</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_runningheads">
           <td>running heads</td>
+
           <td class="rtlTermCell">تشغيل رؤوس؟؟</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_runover">
           <td>runover</td>
+
           <td class="rtlTermCell">تشغيل أكثر</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_scale">
           <td>scale</td>
+
           <td class="rtlTermCell">مقياس، نطاق</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_script">
           <td>script</td>
+
           <td class="rtlTermCell">النص، الكتابة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_secondindenetation">
           <td>second indenetation</td>
+
           <td class="rtlTermCell">المسافة البادئة الثانية</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_secondlevelheading">
           <td>second level heading</td>
+
           <td class="rtlTermCell">عنوان المستوى الثاني</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>Second level and middle size heading between first level heading and third level
-          heading.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>Second level and middle size heading between first level heading
+          and third level heading.</td>
         </tr>
+
         <tr id="def_semicolon">
           <td>semicolon</td>
+
           <td class="rtlTermCell">فاصلة منقوطة</td>
+
           <td class="rtlTermCell">نقطه‌ویرگول</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_sentence">
           <td>sentence</td>
+
           <td class="rtlTermCell">جملة</td>
+
           <td class="rtlTermCell">جمله</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_sideheads">
           <td>sideheads</td>
+
           <td class="rtlTermCell">رؤوس الجانب</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_singlelinealignmentmethod">
           <td>single line alignment method</td>
+
           <td class="rtlTermCell">سطر واحد طريقة محاذاة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>To align a run of text that is shorter than a given line length to designated
-          positions.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>To align a run of text that is shorter than a given line length
+          to designated positions.</td>
         </tr>
+
         <tr id="def_singlerunningheadmethod">
           <td>single running head method</td>
+
           <td class="rtlTermCell">تشغيل واحد طريقة الرأس</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td>A method that puts running heads only on odd pages.</td>
         </tr>
+
         <tr id="def_sinkage">
           <td>sinkage</td>
+
           <td class="rtlTermCell">جماح sinkage</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_softhyphen">
           <td>soft hyphen</td>
+
           <td class="rtlTermCell">واصلة لينة، اصلة تقديرية</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_solidus">
           <td>solidus</td>
+
           <td class="rtlTermCell">الخط المائل</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_sorting">
           <td>sorting</td>
+
           <td class="rtlTermCell">الترتيب</td>
+
           <td class="rtlTermCell">ترتیب</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_space">
           <td>space</td>
+
           <td class="rtlTermCell">فراغ، مساحة</td>
+
           <td class="rtlTermCell">فاصله</td>
-          <td>Amount of space between adjacent characters or lines. It also refers to the blank
-          area between the edges of a hanmen or an illustration and text or other hanmen
-          elements.</td>
+
+          <td>Amount of space between adjacent characters or lines. It also
+          refers to the blank area between the edges of a hanmen or an
+          illustration and text or other hanmen elements.</td>
         </tr>
+
         <tr id="def_spacing">
           <td>spacing</td>
+
           <td class="rtlTermCell">التباعد</td>
+
           <td class="rtlTermCell">فاصله‌گذاری</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_spine">
           <td>spine</td>
+
           <td class="rtlTermCell">العمود</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_spread">
           <td>spread</td>
+
           <td class="rtlTermCell">انتشار</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td>Any two facing pages when opening a book and the like.</td>
         </tr>
+
         <tr id="def_stem">
           <td>stem</td>
+
           <td class="rtlTermCell">جذع</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_style">
           <td>style</td>
+
           <td class="rtlTermCell">أسلوب، النمط</td>
+
           <td class="rtlTermCell">شیوه</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_styleguide">
           <td>style guide</td>
+
           <td class="rtlTermCell">دليل النمط</td>
+
           <td class="rtlTermCell">شیوه‌نامه</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_subheads">
           <td>subheads</td>
+
           <td class="rtlTermCell">العناوين الفرعية</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_subscript(inferior)">
           <td>subscript (inferior)</td>
+
           <td class="rtlTermCell">نص منخفض (أقل شأنا)</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>Smaller face of characters, attached to the lower right or the lower left of a normal
-          size character.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>Smaller face of characters, attached to the lower right or the
+          lower left of a normal size character.</td>
         </tr>
+
         <tr id="def_subtitle">
           <td>subtitle</td>
+
           <td class="rtlTermCell">عنوان فرعي</td>
+
           <td class="rtlTermCell">زیرنویس</td>
+
           <td>Secondary title for headings, subtile.</td>
         </tr>
+
         <tr id="def_superiornumeral">
           <td>superior numeral</td>
+
           <td class="rtlTermCell">الرقم العلوي</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_superscript(superior)">
           <td>superscript (superior)</td>
+
           <td class="rtlTermCell">نص مرتفع (أعلى)</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>Smaller face of characters, attached to the upper right or the upper left of a normal
-          size character.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>Smaller face of characters, attached to the upper right or the
+          upper left of a normal size character.</td>
         </tr>
+
         <tr id="def_symbol">
           <td>symbol</td>
+
           <td class="rtlTermCell">رمز</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_tab">
           <td>tab</td>
+
           <td class="rtlTermCell">التبويب</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_tabsetting">
           <td>tab setting</td>
+
           <td class="rtlTermCell">وضع علامة التبويب</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A method of line composition to align one or more runs of text to designated
-          positions on a line.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A method of line composition to align one or more runs of text to
+          designated positions on a line.</td>
         </tr>
+
         <tr id="def_table">
           <td>table</td>
+
           <td class="rtlTermCell">جدول</td>
+
           <td class="rtlTermCell">جدول</td>
-          <td>Formatted data consisting of characters or numbers, arranged in cells and sometimes
-          divided by lines, in order to present the data in a way that is easier to
-          understand.</td>
+
+          <td>Formatted data consisting of characters or numbers, arranged in
+          cells and sometimes divided by lines, in order to present the data in
+          a way that is easier to understand.</td>
         </tr>
+
         <tr id="def_tableofcontents">
           <td>table of contents</td>
+
           <td class="rtlTermCell">جدول المحتويات</td>
+
           <td class="rtlTermCell">فهرست مطالب</td>
-          <td>A list of headings of contents of a book in page order or arranged by subjects, with
-          page numbers on which each section begins.</td>
+
+          <td>A list of headings of contents of a book in page order or
+          arranged by subjects, with page numbers on which each section
+          begins.</td>
         </tr>
+
         <tr id="def_tailmargin">
           <td>tail margin</td>
+
           <td class="rtlTermCell">هامش الذيل</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_text">
           <td>text</td>
+
           <td class="rtlTermCell">نص</td>
+
           <td class="rtlTermCell">متن</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_textdirection">
           <td>text direction</td>
+
           <td class="rtlTermCell">اتجاه النص</td>
+
           <td class="rtlTermCell">جهت متن</td>
+
           <td>Horizontal setting or vertical setting.</td>
         </tr>
+
         <tr id="def_thinspace">
           <td>thin space</td>
+
           <td class="rtlTermCell">مساحة رقيقة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_thirdlevelheading">
           <td>third level heading</td>
+
           <td class="rtlTermCell">عنوان المستوى الثالث</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td>Headings for smallest or minimum unit of main text in books.</td>
         </tr>
+
         <tr id="def_toplevelheading">
           <td>top level heading</td>
+
           <td class="rtlTermCell">عنوان أعلى مستوى</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td>Headings for largest or muximum unit of main text in books.</td>
         </tr>
+
         <tr id="def_tracking">
           <td>tracking</td>
+
           <td class="rtlTermCell">تتبع</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_transliteration">
           <td>transliteration</td>
+
           <td class="rtlTermCell">الترجمة الصوتية</td>
+
           <td class="rtlTermCell">حرف‌نویسی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_trimsize">
           <td>trim size</td>
+
           <td class="rtlTermCell">حجم التقليم، حجم القَصِّ</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>Dimensions of a full page in a publication, including margins.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>Dimensions of a full page in a publication, including
+          margins.</td>
         </tr>
+
         <tr id="def_typepage">
           <td>type page</td>
+
           <td class="rtlTermCell">نوع الصفحة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_typesizes">
           <td>type sizes</td>
+
           <td class="rtlTermCell">نوع الأحجام</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_typestyles">
           <td>type styles</td>
+
           <td class="rtlTermCell">أنماط الكتابة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_type-picking">
           <td>type-picking</td>
+
           <td class="rtlTermCell">نوع قطف</td>
+
           <td class="rtlTermCell">انتخاب فونت</td>
-          <td>To select metal type for characters needed to print a manuscript. (Metal type is
-          stored in a type case, but because the number of Japanese characters is very large, an
-          extra operation was invented that involves collecting type in a so-called 'bunsen box'
-          before typesetting a manuscript using a composing stick.)</td>
+
+          <td>To select metal type for characters needed to print a manuscript.
+          (Metal type is stored in a type case, but because the number of
+          Japanese characters is very large, an extra operation was invented
+          that involves collecting type in a so-called 'bunsen box' before
+          typesetting a manuscript using a composing stick.)</td>
         </tr>
+
         <tr id="def_typeface">
           <td>typeface</td>
+
           <td class="rtlTermCell">محرف</td>
+
           <td class="rtlTermCell">فونت، قلم</td>
-          <td>A set of letters or symbols, which are designed to have coherent patterns to be used
-          for printing or rendering to a computer screen.</td>
+
+          <td>A set of letters or symbols, which are designed to have coherent
+          patterns to be used for printing or rendering to a computer
+          screen.</td>
         </tr>
+
         <tr id="def_typesetting">
           <td>typesetting</td>
-          <td class="rtlTermCell">تنضيد، تَنْضِيدُ الحُرُوفِ الْمَطْبَعِيَّةِ</td>
+
+          <td class="rtlTermCell">تنضيد، تَنْضِيدُ الحُرُوفِ
+          الْمَطْبَعِيَّةِ</td>
+
           <td class="rtlTermCell">حروفچینی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_typography">
           <td>typography</td>
+
           <td class="rtlTermCell">طباعة الحروف، أسلوب الطباعة</td>
+
           <td class="rtlTermCell">تایپوگرافی</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_unbreakablecharactersrule">
           <td>unbreakable characters rule</td>
+
           <td class="rtlTermCell">قاعدة أحرف غير قابلة للكسر</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A line breaking rule that prohibits breaking a line between consecutive dashes or
-          leaders, or between other specific combinations of characters.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A line breaking rule that prohibits breaking a line between
+          consecutive dashes or leaders, or between other specific combinations
+          of characters.</td>
         </tr>
+
         <tr id="def_underline">
           <td>underline</td>
+
           <td class="rtlTermCell">تسطير من تحت</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A line drawn under a character or a run of text in horizontal writing mode.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A line drawn under a character or a run of text in horizontal
+          writing mode.</td>
         </tr>
+
         <tr id="def_unicameral">
           <td>unicameral</td>
+
           <td class="rtlTermCell">أحادى المجلس</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_Unicode">
           <td>Unicode</td>
+
           <td class="rtlTermCell">يونيكود</td>
+
           <td class="rtlTermCell">یونی‌کُد</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_verticalwritingmode">
           <td>vertical writing mode</td>
+
           <td class="rtlTermCell">وضع الكتابة العمودي</td>
+
           <td class="rtlTermCell">حالت نوشتار عمودی</td>
-          <td>The process or the result of arranging characters on a line from top to bottom, of
-          lines on a page from right to left, and/or of columns on a page from top to bottom.</td>
+
+          <td>The process or the result of arranging characters on a line from
+          top to bottom, of lines on a page from right to left, and/or of
+          columns on a page from top to bottom.</td>
         </tr>
+
         <tr id="def_volume">
           <td>volume</td>
+
           <td class="rtlTermCell">حجم</td>
+
           <td class="rtlTermCell">جلد</td>
-          <td><br>
-</td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_weight">
           <td>weight</td>
+
           <td class="rtlTermCell">ثقل</td>
-          <td class="rtlTermCell"><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
           <td>A measurement of the thickness of fonts.</td>
         </tr>
+
         <tr id="def_Westernalphabet">
           <td>Western alphabet</td>
+
           <td class="rtlTermCell">الأبجدية الغربية</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_Westernlanguages">
           <td>Western languages</td>
+
           <td class="rtlTermCell">أرملة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_widow">
           <td>widow</td>
+
           <td class="rtlTermCell">تعديل أرملة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>The term in Western text layout to describe that the last line of a paragraph with
-          only a few words appears at the top of a new page or a column.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>The term in Western text layout to describe that the last line of
+          a paragraph with only a few words appears at the top of a new page or
+          a column.</td>
         </tr>
+
         <tr id="def_widowadjustment">
           <td>widow adjustment</td>
+
           <td class="rtlTermCell">تقسيم كلمة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td>A method of line composition to adjust lines in a paragraph so that the last line
-          consists of more than a given number of characters.</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td>A method of line composition to adjust lines in a paragraph so
+          that the last line consists of more than a given number of
+          characters.</td>
         </tr>
+
         <tr id="def_worddivision">
           <td>word division</td>
+
           <td class="rtlTermCell">قسم كلمة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_wordspace">
           <td>word space</td>
+
           <td class="rtlTermCell">مساحة كلمة</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
+
         <tr id="def_x-height">
           <td>x-height</td>
+
           <td class="rtlTermCell">س الارتفاع</td>
-          <td class="rtlTermCell"><br>
-</td>
-          <td><br>
-</td>
+
+          <td class="rtlTermCell"><br></td>
+
+          <td><br></td>
         </tr>
       </tbody>
     </table>
   </section>
 
-
-  
-<section class="appendix" id="acknowledgements">
+  <section class="appendix"
+           id="acknowledgements">
     <h2>Acknowledgements</h2>
-    <p>Special thanks to the following people who contributed to this document (contributors' names
-    listed in in alphabetic order).</p>
+
+    <p>Special thanks to the following people who contributed to this document
+    (contributors' names listed in in alphabetic order).</p>
+
     <p class="acknowledgement">This Person, That Person, etc</p>
-    <p data-lang="en">Please find the latest info of the contributors at the <a href="https://github.com/w3c/alreq/graphs/contributors">GitHub contributors list</a>.</p>
+
+    <p data-lang="en">Please find the latest info of the contributors at the
+    <a href="https://github.com/w3c/alreq/graphs/contributors">GitHub
+    contributors list</a>.</p>
   </section>
-
-
-
-
-</body></html>
+</body>
+</html>

--- a/local.css
+++ b/local.css
@@ -32,6 +32,26 @@ del {
   color: silver;
 }
 
+.img {
+    width: 90%;
+}
+
+.body:link:active {
+    color: #EE0000;
+}
+
+.body:visited:active {
+    color: #EE0000;
+}
+
+.body:link {
+    color: #0000EE;
+}
+
+.body:visited {
+    color: #551A8B;
+}
+
 figure {
   margin-bottom: 2em;
   text-align: center;

--- a/misc/scripts/tidy-recipe.sh
+++ b/misc/scripts/tidy-recipe.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+tidy -utf8 -w 80 --indent-attributes true --tidy-mark false --output-html true -i --new-blocklevel-tags section,figure,figcaption -m index.html


### PR DESCRIPTION
– Validating with W3C validator and fixing all the errors;
– Using HTMLTidy to clean the HTML, limiting to 80 chars per line, etc.;
– Since the diffs are too large for Github to show visually, I have a diff report generated as HTML which can be downloaded from [here](https://drive.google.com/open?id=0B7e3aAsGonX5MzFCS3B5MG9pVTg);
– Added the script with HTMLTidy settings used to the repository.
