### PR TITLE
Consistent HTML tags for section titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -887,7 +887,7 @@
 
     <p>The following tables list Unicode characters used for Arabic script, excluding ASCII. Each table has two columns named <span class="qterm">Ar</span> and <span class="qterm">Fa</span> which denote which characters are used for Arabic or Persian languages, respectively. A black circle (●) under each of these two columns means that a character is used for that language. A white circle (○) denotes a character that is auxiliary for that language. An X mark (✕) means the character is not used for that langauge.</p>
 
-    <section>
+    <section id="h_character_tables_alphabetical_characters">
       <h2>Alphabetical characters</h2>
 
       <table class="characters">
@@ -1509,7 +1509,7 @@
       </table>
     </section>
 
-    <section>
+    <section id="h_character_tables_diacritics">
       <h2>Diacritics</h2>
 
       <table class="characters">
@@ -1675,7 +1675,7 @@
       </table>
     </section>
 
-    <section>
+    <section id="h_character_tables_numeral_characters">
       <h2>Numeral characters</h2>
 
       <table class="characters">
@@ -1937,7 +1937,7 @@
       </table>
     </section>
 
-    <section>
+    <section id="h_character_tables_punctuations_and_symbols">
       <h2>Punctuations and symbols</h2>
 
       <table class="characters">
@@ -2175,7 +2175,7 @@
       </table>
     </section>
 
-    <section>
+    <section id="h_character_tables_control_characters">
       <h2>Control characters</h2>
 
       <table class="characters">

--- a/index.html
+++ b/index.html
@@ -484,7 +484,7 @@
       </section>
 
       <section id="h_fonts">
-        <h3><span style="font-weight: bold;">Fonts</span></h3>
+        <h3>Fonts</h3>
 
         <p>Arabic script counts 26 letters, and mostly 19 basic shapes. Since letters change according to their position in the word, Arabic set of glyph may range to more than one hundred shapes. If one count possible ligatures, and different combination of joining forms (see above), the number of glyph can increase further. Not sure that typeface design can accommodate all needs, even though some present typefaces can run hundred of shapes.</p>
 

--- a/index.html
+++ b/index.html
@@ -242,7 +242,7 @@
     </section>
 
     <section id="h_font_and_typographical_considerations">
-      <h3><a href="#h_font_and_typographical_considerations">Font and Typographical considerations</a></h3>
+      <h3>Font and Typographical considerations</h3>
 
       <section id="h_arabic_style_and_calligraphy">
         <h4>Arabic Style and Calligraphy</h4>
@@ -510,10 +510,10 @@
   </section>
 
   <section id="h_characters_and_words">
-    <h2><a href="#h_characters_and_words">Characters and Words</a></h2>
+    <h2>Characters and Words</h2>
 
     <section id="h_diacritics">
-      <h3><a href="#h_diacritics">Diacritics</a></h3>
+      <h3>Diacritics</h3>
 
       <p>In Arabic script text it is unusual to use diacritics for vowel information and for consonant lengthening.</p>
 
@@ -546,10 +546,10 @@
   </section>
 
   <section id="h_lines_and_paragraphs">
-    <h2><a href="#h_lines_and_paragraphs">Lines and Paragraphs</a></h2>
+    <h2>Lines and Paragraphs</h2>
 
     <section id="h_line_breaking">
-      <h3><a href="#h_line_breaking">Line breaking</a></h3>
+      <h3>Line breaking</h3>
 
       <p>When Arabic text doesn't fit within the available line width, the text is wrapped to the next line between words.</p>
 
@@ -577,7 +577,7 @@
     </section>
 
     <section id="h_justification">
-      <h3><a href="#h_justification">Justification</a></h3>
+      <h3>Justification</h3>
 
       <div class="note">
         <h4>Notes, Links, …</h4>
@@ -786,7 +786,7 @@
     </section>
 
     <section id="h_para_line_alignment">
-      <h3><a href="#h_para_line_alignment">Paragraph and line alignment</a></h3>
+      <h3>Paragraph and line alignment</h3>
 
       <p>Lines of Arabic script text are normally right aligned within the page.</p>
 
@@ -827,7 +827,7 @@
   </section>
 
   <section id="h_pages">
-    <h2><a href="#h_pages">Pages</a></h2>
+    <h2>Pages</h2>
 
     <p>Topic Keywords:</p>
 

--- a/index.html
+++ b/index.html
@@ -245,7 +245,7 @@
       <h2><a href="#h_font_and_typographical_considerations">Font and Typographical considerations</a></h2>
 
       <section id="h_arabic_style_and_calligraphy">
-        <h3>Arabic Style and Calligraphy</h3>
+        <h2>Arabic Style and Calligraphy</h2>
 
         <p>Arabic styling and writing has its origins in Islamic art and civilization, and was widely used to decorate mosques and palaces, as well as to create beautiful manuscripts and books, and especially to copy the <em>Kor'an</em>. Arabic script is cursive, making it viable to support different geometric shapes overlapping and composition. Words can be written in a very condensed form as well as stretched into elongated shapes, and the scribes and artists of Islam labored with passion to take advantage of all these possibilities.</p>
 
@@ -258,7 +258,7 @@
       </section>
 
       <section id="h_different_writing_styles">
-        <h3>Different Writing Styles</h3>
+        <h2>Different Writing Styles</h2>
 
         <p>Basics and principles of Arabic writing were defined by <em>Ibn Moqlah</em> (886-940 Higra), who defined six styles of writing: <em>Kufi</em>, <em>Thuluth</em>, <em>Naskh</em>, <em>Ruqʻa</em>, <em>Taʻliq</em> and <em>Diwani</em>.</p>
 
@@ -358,7 +358,7 @@
       </section>
 
       <section id="h_arabic_script_and_typography">
-        <h3>Arabic Script and Typography</h3>
+        <h2>Arabic Script and Typography</h2>
 
         <p>Arabic script has some characteristics that are challenging for typographers and font designers. Examples bellow show some characteristics worth to be considered carefully. How could typography, which came late to the Arabic world, then follow the tradition of the many authors and artists who manually shaped the Arabic writing over decades? even in it's simplest <span style="font-style: italic;">Naskh</span> style?</p>
 
@@ -484,7 +484,7 @@
       </section>
 
       <section id="h_fonts">
-        <h3>Fonts</h3>
+        <h2>Fonts</h2>
 
         <p>Arabic script counts 26 letters, and mostly 19 basic shapes. Since letters change according to their position in the word, Arabic set of glyph may range to more than one hundred shapes. If one count possible ligatures, and different combination of joining forms (see above), the number of glyph can increase further. Not sure that typeface design can accommodate all needs, even though some present typefaces can run hundred of shapes.</p>
 
@@ -513,7 +513,7 @@
     <h2><a href="#h_characters_and_words">Characters and Words</a></h2>
 
     <section id="h_diacritics">
-      <h3><a href="#h_diacritics">Diacritics</a></h3>
+      <h2><a href="#h_diacritics">Diacritics</a></h2>
 
       <p>In Arabic script text it is unusual to use diacritics for vowel information and for consonant lengthening.</p>
 
@@ -549,7 +549,7 @@
     <h2><a href="#h_lines_and_paragraphs">Lines and Paragraphs</a></h2>
 
     <section id="h_line_breaking">
-      <h3><a href="#h_line_breaking">Line breaking</a></h3>
+      <h2><a href="#h_line_breaking">Line breaking</a></h2>
 
       <p>When Arabic text doesn't fit within the available line width, the text is wrapped to the next line between words.</p>
 
@@ -786,7 +786,7 @@
     </section>
 
     <section id="h_para_line_alignment">
-      <h3><a href="#h_para_line_alignment">Paragraph and line alignment</a></h3>
+      <h2><a href="#h_para_line_alignment">Paragraph and line alignment</a></h2>
 
       <p>Lines of Arabic script text are normally right aligned within the page.</p>
 
@@ -887,1513 +887,1523 @@
 
     <p>The following tables list Unicode characters used for Arabic script, excluding ASCII. Each table has two columns named <span class="qterm">Ar</span> and <span class="qterm">Fa</span> which denote which characters are used for Arabic or Persian languages, respectively. A black circle (●) under each of these two columns means that a character is used for that language. A white circle (○) denotes a character that is auxiliary for that language. An X mark (✕) means the character is not used for that langauge.</p>
 
-    <h3>Alphabetical characters</h3>
+    <section>
+      <h2>Alphabetical characters</h2>
 
-    <table class="characters">
-      <thead>
-        <tr>
-          <th class="charColumn">Character</th>
+      <table class="characters">
+        <thead>
+          <tr>
+            <th class="charColumn">Character</th>
 
-          <th class="ucsColumn">UCS</th>
+            <th class="ucsColumn">UCS</th>
 
-          <th class="charnameColumn">Name</th>
+            <th class="charnameColumn">Name</th>
 
-          <th class="languageColumn">Ar</th>
+            <th class="languageColumn">Ar</th>
 
-          <th class="languageColumn">Fa</th>
-        </tr>
-      </thead>
+            <th class="languageColumn">Fa</th>
+          </tr>
+        </thead>
 
-      <tbody>
-        <tr id="def_U+0621">
-          <td class="rtlTermCell" lang="ar">ء</td>
+        <tbody>
+          <tr id="def_U+0621">
+            <td class="rtlTermCell" lang="ar">ء</td>
 
-          <td class="uname">U+0621</td>
+            <td class="uname">U+0621</td>
 
-          <td class="uname">ARABIC LETTER HAMZA</td>
+            <td class="uname">ARABIC LETTER HAMZA</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0622">
-          <td class="rtlTermCell" lang="ar">آ</td>
+          <tr id="def_U+0622">
+            <td class="rtlTermCell" lang="ar">آ</td>
 
-          <td class="uname">U+0622</td>
+            <td class="uname">U+0622</td>
 
-          <td class="uname">ARABIC LETTER ALEF WITH MADDA ABOVE</td>
+            <td class="uname">ARABIC LETTER ALEF WITH MADDA ABOVE</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0623">
-          <td class="rtlTermCell" lang="ar">أ</td>
+          <tr id="def_U+0623">
+            <td class="rtlTermCell" lang="ar">أ</td>
 
-          <td class="uname">U+0623</td>
+            <td class="uname">U+0623</td>
 
-          <td class="uname">ARABIC LETTER ALEF WITH HAMZA ABOVE</td>
+            <td class="uname">ARABIC LETTER ALEF WITH HAMZA ABOVE</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0624">
-          <td class="rtlTermCell" lang="ar">ؤ</td>
+          <tr id="def_U+0624">
+            <td class="rtlTermCell" lang="ar">ؤ</td>
 
-          <td class="uname">U+0624</td>
+            <td class="uname">U+0624</td>
 
-          <td class="uname">ARABIC LETTER WAW WITH HAMZA ABOVE</td>
+            <td class="uname">ARABIC LETTER WAW WITH HAMZA ABOVE</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0625">
-          <td class="rtlTermCell" lang="ar">إ</td>
+          <tr id="def_U+0625">
+            <td class="rtlTermCell" lang="ar">إ</td>
 
-          <td class="uname">U+0625</td>
+            <td class="uname">U+0625</td>
 
-          <td class="uname">ARABIC LETTER ALEF WITH HAMZA BELOW</td>
+            <td class="uname">ARABIC LETTER ALEF WITH HAMZA BELOW</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+0626">
-          <td class="rtlTermCell" lang="ar">ئ</td>
+          <tr id="def_U+0626">
+            <td class="rtlTermCell" lang="ar">ئ</td>
 
-          <td class="uname">U+0626</td>
+            <td class="uname">U+0626</td>
 
-          <td class="uname">ARABIC LETTER YEH WITH HAMZA ABOVE</td>
+            <td class="uname">ARABIC LETTER YEH WITH HAMZA ABOVE</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0627">
-          <td class="rtlTermCell" lang="ar">ا</td>
+          <tr id="def_U+0627">
+            <td class="rtlTermCell" lang="ar">ا</td>
 
-          <td class="uname">U+0627</td>
+            <td class="uname">U+0627</td>
 
-          <td class="uname">ARABIC LETTER ALEF</td>
+            <td class="uname">ARABIC LETTER ALEF</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0628">
-          <td class="rtlTermCell" lang="ar">ب</td>
+          <tr id="def_U+0628">
+            <td class="rtlTermCell" lang="ar">ب</td>
 
-          <td class="uname">U+0628</td>
+            <td class="uname">U+0628</td>
 
-          <td class="uname">ARABIC LETTER BEH</td>
+            <td class="uname">ARABIC LETTER BEH</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0629">
-          <td class="rtlTermCell" lang="ar">ة</td>
+          <tr id="def_U+0629">
+            <td class="rtlTermCell" lang="ar">ة</td>
 
-          <td class="uname">U+0629</td>
+            <td class="uname">U+0629</td>
 
-          <td class="uname">ARABIC LETTER TEH MARBUTA</td>
+            <td class="uname">ARABIC LETTER TEH MARBUTA</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+062A">
-          <td class="rtlTermCell" lang="ar">ت</td>
+          <tr id="def_U+062A">
+            <td class="rtlTermCell" lang="ar">ت</td>
 
-          <td class="uname">U+062A</td>
+            <td class="uname">U+062A</td>
 
-          <td class="uname">ARABIC LETTER TEH</td>
+            <td class="uname">ARABIC LETTER TEH</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+062B">
-          <td class="rtlTermCell" lang="ar">ث</td>
+          <tr id="def_U+062B">
+            <td class="rtlTermCell" lang="ar">ث</td>
 
-          <td class="uname">U+062B</td>
+            <td class="uname">U+062B</td>
 
-          <td class="uname">ARABIC LETTER THEH</td>
+            <td class="uname">ARABIC LETTER THEH</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+062C">
-          <td class="rtlTermCell" lang="ar">ج</td>
+          <tr id="def_U+062C">
+            <td class="rtlTermCell" lang="ar">ج</td>
 
-          <td class="uname">U+062C</td>
+            <td class="uname">U+062C</td>
 
-          <td class="uname">ARABIC LETTER JEEM</td>
+            <td class="uname">ARABIC LETTER JEEM</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+062D">
-          <td class="rtlTermCell" lang="ar">ح</td>
+          <tr id="def_U+062D">
+            <td class="rtlTermCell" lang="ar">ح</td>
 
-          <td class="uname">U+062D</td>
+            <td class="uname">U+062D</td>
 
-          <td class="uname">ARABIC LETTER HAH</td>
+            <td class="uname">ARABIC LETTER HAH</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+062E">
-          <td class="rtlTermCell" lang="ar">خ</td>
+          <tr id="def_U+062E">
+            <td class="rtlTermCell" lang="ar">خ</td>
 
-          <td class="uname">U+062E</td>
+            <td class="uname">U+062E</td>
 
-          <td class="uname">ARABIC LETTER KHAH</td>
+            <td class="uname">ARABIC LETTER KHAH</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+062F">
-          <td class="rtlTermCell" lang="ar">د</td>
+          <tr id="def_U+062F">
+            <td class="rtlTermCell" lang="ar">د</td>
 
-          <td class="uname">U+062F</td>
+            <td class="uname">U+062F</td>
 
-          <td class="uname">ARABIC LETTER DAL</td>
+            <td class="uname">ARABIC LETTER DAL</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0630">
-          <td class="rtlTermCell" lang="ar">ذ</td>
+          <tr id="def_U+0630">
+            <td class="rtlTermCell" lang="ar">ذ</td>
 
-          <td class="uname">U+0630</td>
+            <td class="uname">U+0630</td>
 
-          <td class="uname">ARABIC LETTER THAL</td>
+            <td class="uname">ARABIC LETTER THAL</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0631">
-          <td class="rtlTermCell" lang="ar">ر</td>
+          <tr id="def_U+0631">
+            <td class="rtlTermCell" lang="ar">ر</td>
 
-          <td class="uname">U+0631</td>
+            <td class="uname">U+0631</td>
 
-          <td class="uname">ARABIC LETTER REH</td>
+            <td class="uname">ARABIC LETTER REH</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0632">
-          <td class="rtlTermCell" lang="ar">ز</td>
+          <tr id="def_U+0632">
+            <td class="rtlTermCell" lang="ar">ز</td>
 
-          <td class="uname">U+0632</td>
+            <td class="uname">U+0632</td>
 
-          <td class="uname">ARABIC LETTER ZAIN</td>
+            <td class="uname">ARABIC LETTER ZAIN</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0633">
-          <td class="rtlTermCell" lang="ar">س</td>
+          <tr id="def_U+0633">
+            <td class="rtlTermCell" lang="ar">س</td>
 
-          <td class="uname">U+0633</td>
+            <td class="uname">U+0633</td>
 
-          <td class="uname">ARABIC LETTER SEEN</td>
+            <td class="uname">ARABIC LETTER SEEN</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0634">
-          <td class="rtlTermCell" lang="ar">ش</td>
+          <tr id="def_U+0634">
+            <td class="rtlTermCell" lang="ar">ش</td>
 
-          <td class="uname">U+0634</td>
+            <td class="uname">U+0634</td>
 
-          <td class="uname">ARABIC LETTER SHEEN</td>
+            <td class="uname">ARABIC LETTER SHEEN</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0635">
-          <td class="rtlTermCell" lang="ar">ص</td>
+          <tr id="def_U+0635">
+            <td class="rtlTermCell" lang="ar">ص</td>
 
-          <td class="uname">U+0635</td>
+            <td class="uname">U+0635</td>
 
-          <td class="uname">ARABIC LETTER SAD</td>
+            <td class="uname">ARABIC LETTER SAD</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0636">
-          <td class="rtlTermCell" lang="ar">ض</td>
+          <tr id="def_U+0636">
+            <td class="rtlTermCell" lang="ar">ض</td>
 
-          <td class="uname">U+0636</td>
+            <td class="uname">U+0636</td>
 
-          <td class="uname">ARABIC LETTER DAD</td>
+            <td class="uname">ARABIC LETTER DAD</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0637">
-          <td class="rtlTermCell" lang="ar">ط</td>
+          <tr id="def_U+0637">
+            <td class="rtlTermCell" lang="ar">ط</td>
 
-          <td class="uname">U+0637</td>
+            <td class="uname">U+0637</td>
 
-          <td class="uname">ARABIC LETTER TAH</td>
+            <td class="uname">ARABIC LETTER TAH</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0638">
-          <td class="rtlTermCell" lang="ar">ظ</td>
+          <tr id="def_U+0638">
+            <td class="rtlTermCell" lang="ar">ظ</td>
 
-          <td class="uname">U+0638</td>
+            <td class="uname">U+0638</td>
 
-          <td class="uname">ARABIC LETTER ZAH</td>
+            <td class="uname">ARABIC LETTER ZAH</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0639">
-          <td class="rtlTermCell" lang="ar">ع</td>
+          <tr id="def_U+0639">
+            <td class="rtlTermCell" lang="ar">ع</td>
 
-          <td class="uname">U+0639</td>
+            <td class="uname">U+0639</td>
 
-          <td class="uname">ARABIC LETTER AIN</td>
+            <td class="uname">ARABIC LETTER AIN</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+063A">
-          <td class="rtlTermCell" lang="ar">غ</td>
+          <tr id="def_U+063A">
+            <td class="rtlTermCell" lang="ar">غ</td>
 
-          <td class="uname">U+063A</td>
+            <td class="uname">U+063A</td>
 
-          <td class="uname">ARABIC LETTER GHAIN</td>
+            <td class="uname">ARABIC LETTER GHAIN</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0641">
-          <td class="rtlTermCell" lang="ar">ف</td>
+          <tr id="def_U+0641">
+            <td class="rtlTermCell" lang="ar">ف</td>
 
-          <td class="uname">U+0641</td>
+            <td class="uname">U+0641</td>
 
-          <td class="uname">ARABIC LETTER FEH</td>
+            <td class="uname">ARABIC LETTER FEH</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0642">
-          <td class="rtlTermCell" lang="ar">ق</td>
+          <tr id="def_U+0642">
+            <td class="rtlTermCell" lang="ar">ق</td>
 
-          <td class="uname">U+0642</td>
+            <td class="uname">U+0642</td>
 
-          <td class="uname">ARABIC LETTER QAF</td>
+            <td class="uname">ARABIC LETTER QAF</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0643">
-          <td class="rtlTermCell" lang="ar">ك</td>
+          <tr id="def_U+0643">
+            <td class="rtlTermCell" lang="ar">ك</td>
 
-          <td class="uname">U+0643</td>
+            <td class="uname">U+0643</td>
 
-          <td class="uname">ARABIC LETTER KAF</td>
+            <td class="uname">ARABIC LETTER KAF</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+0644">
-          <td class="rtlTermCell" lang="ar">ل</td>
+          <tr id="def_U+0644">
+            <td class="rtlTermCell" lang="ar">ل</td>
 
-          <td class="uname">U+0644</td>
+            <td class="uname">U+0644</td>
 
-          <td class="uname">ARABIC LETTER LAM</td>
+            <td class="uname">ARABIC LETTER LAM</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0645">
-          <td class="rtlTermCell" lang="ar">م</td>
+          <tr id="def_U+0645">
+            <td class="rtlTermCell" lang="ar">م</td>
 
-          <td class="uname">U+0645</td>
+            <td class="uname">U+0645</td>
 
-          <td class="uname">ARABIC LETTER MEEM</td>
+            <td class="uname">ARABIC LETTER MEEM</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0646">
-          <td class="rtlTermCell" lang="ar">ن</td>
+          <tr id="def_U+0646">
+            <td class="rtlTermCell" lang="ar">ن</td>
 
-          <td class="uname">U+0646</td>
+            <td class="uname">U+0646</td>
 
-          <td class="uname">ARABIC LETTER NOON</td>
+            <td class="uname">ARABIC LETTER NOON</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0647">
-          <td class="rtlTermCell" lang="ar">ه</td>
+          <tr id="def_U+0647">
+            <td class="rtlTermCell" lang="ar">ه</td>
 
-          <td class="uname">U+0647</td>
+            <td class="uname">U+0647</td>
 
-          <td class="uname">ARABIC LETTER HEH</td>
+            <td class="uname">ARABIC LETTER HEH</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0648">
-          <td class="rtlTermCell" lang="ar">و</td>
+          <tr id="def_U+0648">
+            <td class="rtlTermCell" lang="ar">و</td>
 
-          <td class="uname">U+0648</td>
+            <td class="uname">U+0648</td>
 
-          <td class="uname">ARABIC LETTER WAW</td>
+            <td class="uname">ARABIC LETTER WAW</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0649">
-          <td class="rtlTermCell" lang="ar">ى</td>
+          <tr id="def_U+0649">
+            <td class="rtlTermCell" lang="ar">ى</td>
 
-          <td class="uname">U+0649</td>
+            <td class="uname">U+0649</td>
 
-          <td class="uname">ARABIC LETTER ALEF MAKSURA</td>
+            <td class="uname">ARABIC LETTER ALEF MAKSURA</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+064A">
-          <td class="rtlTermCell" lang="ar">ي</td>
+          <tr id="def_U+064A">
+            <td class="rtlTermCell" lang="ar">ي</td>
 
-          <td class="uname">U+064A</td>
+            <td class="uname">U+064A</td>
 
-          <td class="uname">ARABIC LETTER YEH</td>
+            <td class="uname">ARABIC LETTER YEH</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+066F">
-          <td class="rtlTermCell" lang="ar">ٯ</td>
+          <tr id="def_U+066F">
+            <td class="rtlTermCell" lang="ar">ٯ</td>
 
-          <td class="uname">U+066F</td>
+            <td class="uname">U+066F</td>
 
-          <td class="uname">ARABIC LETTER DOTLESS QAF</td>
+            <td class="uname">ARABIC LETTER DOTLESS QAF</td>
 
-          <td class="langMark">○</td>
+            <td class="langMark">○</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+0671">
-          <td class="rtlTermCell" lang="ar">ٱ</td>
+          <tr id="def_U+0671">
+            <td class="rtlTermCell" lang="ar">ٱ</td>
 
-          <td class="uname">U+0671</td>
+            <td class="uname">U+0671</td>
 
-          <td class="uname">ARABIC LETTER ALEF WASLA</td>
+            <td class="uname">ARABIC LETTER ALEF WASLA</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+067E">
-          <td class="rtlTermCell" lang="ar">پ</td>
+          <tr id="def_U+067E">
+            <td class="rtlTermCell" lang="ar">پ</td>
 
-          <td class="uname">U+067E</td>
+            <td class="uname">U+067E</td>
 
-          <td class="uname">ARABIC LETTER PEH</td>
+            <td class="uname">ARABIC LETTER PEH</td>
 
-          <td class="langMark">○</td>
+            <td class="langMark">○</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0686">
-          <td class="rtlTermCell" lang="ar">چ</td>
+          <tr id="def_U+0686">
+            <td class="rtlTermCell" lang="ar">چ</td>
 
-          <td class="uname">U+0686</td>
+            <td class="uname">U+0686</td>
 
-          <td class="uname">ARABIC LETTER TCHEH</td>
+            <td class="uname">ARABIC LETTER TCHEH</td>
 
-          <td class="langMark">○</td>
+            <td class="langMark">○</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0698">
-          <td class="rtlTermCell" lang="ar">ژ</td>
+          <tr id="def_U+0698">
+            <td class="rtlTermCell" lang="ar">ژ</td>
 
-          <td class="uname">U+0698</td>
+            <td class="uname">U+0698</td>
 
-          <td class="uname">ARABIC LETTER JEH</td>
+            <td class="uname">ARABIC LETTER JEH</td>
 
-          <td class="langMark">○</td>
+            <td class="langMark">○</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+069C">
-          <td class="rtlTermCell" lang="ar">ڜ</td>
+          <tr id="def_U+069C">
+            <td class="rtlTermCell" lang="ar">ڜ</td>
 
-          <td class="uname">U+069C</td>
+            <td class="uname">U+069C</td>
 
-          <td class="uname">ARABIC LETTER SEEN WITH THREE DOTS BELOW AND THREE DOTS ABOVE</td>
+            <td class="uname">ARABIC LETTER SEEN WITH THREE DOTS BELOW AND THREE DOTS ABOVE</td>
 
-          <td class="langMark">○</td>
+            <td class="langMark">○</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+06A2">
-          <td class="rtlTermCell" lang="ar">ڢ</td>
+          <tr id="def_U+06A2">
+            <td class="rtlTermCell" lang="ar">ڢ</td>
 
-          <td class="uname">U+06A2</td>
+            <td class="uname">U+06A2</td>
 
-          <td class="uname">ARABIC LETTER FEH WITH DOT MOVED BELOW</td>
+            <td class="uname">ARABIC LETTER FEH WITH DOT MOVED BELOW</td>
 
-          <td class="langMark">○</td>
+            <td class="langMark">○</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+06A4">
-          <td class="rtlTermCell" lang="ar">ڤ</td>
+          <tr id="def_U+06A4">
+            <td class="rtlTermCell" lang="ar">ڤ</td>
 
-          <td class="uname">U+06A4</td>
+            <td class="uname">U+06A4</td>
 
-          <td class="uname">ARABIC LETTER VEH</td>
+            <td class="uname">ARABIC LETTER VEH</td>
 
-          <td class="langMark">○</td>
+            <td class="langMark">○</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+06A5">
-          <td class="rtlTermCell" lang="ar">ڥ</td>
+          <tr id="def_U+06A5">
+            <td class="rtlTermCell" lang="ar">ڥ</td>
 
-          <td class="uname">U+06A5</td>
+            <td class="uname">U+06A5</td>
 
-          <td class="uname">ARABIC LETTER FEH WITH THREE DOTS BELOW</td>
+            <td class="uname">ARABIC LETTER FEH WITH THREE DOTS BELOW</td>
 
-          <td class="langMark">○</td>
+            <td class="langMark">○</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+06A7">
-          <td class="rtlTermCell" lang="ar">ڧ</td>
+          <tr id="def_U+06A7">
+            <td class="rtlTermCell" lang="ar">ڧ</td>
 
-          <td class="uname">U+06A7</td>
+            <td class="uname">U+06A7</td>
 
-          <td class="uname">ARABIC LETTER QAF WITH DOT ABOVE</td>
+            <td class="uname">ARABIC LETTER QAF WITH DOT ABOVE</td>
 
-          <td class="langMark">○</td>
+            <td class="langMark">○</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+06A8">
-          <td class="rtlTermCell" lang="ar">ڨ</td>
+          <tr id="def_U+06A8">
+            <td class="rtlTermCell" lang="ar">ڨ</td>
 
-          <td class="uname">U+06A8</td>
+            <td class="uname">U+06A8</td>
 
-          <td class="uname">ARABIC LETTER QAF WITH THREE DOTS ABOVE</td>
+            <td class="uname">ARABIC LETTER QAF WITH THREE DOTS ABOVE</td>
 
-          <td class="langMark">○</td>
+            <td class="langMark">○</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+06A9">
-          <td class="rtlTermCell" lang="ar">ک</td>
+          <tr id="def_U+06A9">
+            <td class="rtlTermCell" lang="ar">ک</td>
 
-          <td class="uname">U+06A9</td>
+            <td class="uname">U+06A9</td>
 
-          <td class="uname">ARABIC LETTER KEHEH</td>
+            <td class="uname">ARABIC LETTER KEHEH</td>
 
-          <td class="langMark">○</td>
+            <td class="langMark">○</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+06AF">
-          <td class="rtlTermCell" lang="ar">گ</td>
+          <tr id="def_U+06AF">
+            <td class="rtlTermCell" lang="ar">گ</td>
 
-          <td class="uname">U+06AF</td>
+            <td class="uname">U+06AF</td>
 
-          <td class="uname">ARABIC LETTER GAF</td>
+            <td class="uname">ARABIC LETTER GAF</td>
 
-          <td class="langMark">○</td>
+            <td class="langMark">○</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+06CC">
-          <td class="rtlTermCell" lang="ar">ی</td>
+          <tr id="def_U+06CC">
+            <td class="rtlTermCell" lang="ar">ی</td>
 
-          <td class="uname">U+06CC</td>
+            <td class="uname">U+06CC</td>
 
-          <td class="uname">ARABIC LETTER FARSI YEH</td>
+            <td class="uname">ARABIC LETTER FARSI YEH</td>
 
-          <td class="langMark">○</td>
+            <td class="langMark">○</td>
 
-          <td class="langMark">●</td>
-        </tr>
-      </tbody>
-    </table>
+            <td class="langMark">●</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
 
-    <h3>Diacritics</h3>
+    <section>
+      <h2>Diacritics</h2>
 
-    <table class="characters">
-      <thead>
-        <tr>
-          <th class="charColumn">Character</th>
+      <table class="characters">
+        <thead>
+          <tr>
+            <th class="charColumn">Character</th>
 
-          <th class="ucsColumn">UCS</th>
+            <th class="ucsColumn">UCS</th>
 
-          <th class="charnameColumn">Name</th>
+            <th class="charnameColumn">Name</th>
 
-          <th class="languageColumn">Ar</th>
+            <th class="languageColumn">Ar</th>
 
-          <th class="languageColumn">Fa</th>
-        </tr>
-      </thead>
+            <th class="languageColumn">Fa</th>
+          </tr>
+        </thead>
 
-      <tbody>
-        <tr id="def_U+064B">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+064B.svg" alt="ً" class="charimage"></td>
+        <tbody>
+          <tr id="def_U+064B">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+064B.svg" alt="ً" class="charimage"></td>
 
-          <td class="uname">U+064B</td>
+            <td class="uname">U+064B</td>
 
-          <td class="uname">ARABIC FATHATAN</td>
+            <td class="uname">ARABIC FATHATAN</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+064C">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+064C.svg" alt="ٌ" class="charimage"></td>
+          <tr id="def_U+064C">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+064C.svg" alt="ٌ" class="charimage"></td>
 
-          <td class="uname">U+064C</td>
+            <td class="uname">U+064C</td>
 
-          <td class="uname">ARABIC DAMMATAN</td>
+            <td class="uname">ARABIC DAMMATAN</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+064D">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+064D.svg" alt="ٍ" class="charimage"></td>
+          <tr id="def_U+064D">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+064D.svg" alt="ٍ" class="charimage"></td>
 
-          <td class="uname">U+064D</td>
+            <td class="uname">U+064D</td>
 
-          <td class="uname">ARABIC KASRATAN</td>
+            <td class="uname">ARABIC KASRATAN</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+064E">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+064E.svg" alt="َ" class="charimage"></td>
+          <tr id="def_U+064E">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+064E.svg" alt="َ" class="charimage"></td>
 
-          <td class="uname">U+064E</td>
+            <td class="uname">U+064E</td>
 
-          <td class="uname">ARABIC FATHA</td>
+            <td class="uname">ARABIC FATHA</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+064F">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+064F.svg" alt="ُ" class="charimage"></td>
+          <tr id="def_U+064F">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+064F.svg" alt="ُ" class="charimage"></td>
 
-          <td class="uname">U+064F</td>
+            <td class="uname">U+064F</td>
 
-          <td class="uname">ARABIC DAMMA</td>
+            <td class="uname">ARABIC DAMMA</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+0650">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+0650.svg" alt="ِ" class="charimage"></td>
+          <tr id="def_U+0650">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+0650.svg" alt="ِ" class="charimage"></td>
 
-          <td class="uname">U+0650</td>
+            <td class="uname">U+0650</td>
 
-          <td class="uname">ARABIC KASRA</td>
+            <td class="uname">ARABIC KASRA</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+0651">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+0651.svg" alt="ّ" class="charimage"></td>
+          <tr id="def_U+0651">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+0651.svg" alt="ّ" class="charimage"></td>
 
-          <td class="uname">U+0651</td>
+            <td class="uname">U+0651</td>
 
-          <td class="uname">ARABIC SHADDA</td>
+            <td class="uname">ARABIC SHADDA</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0652">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+0652.svg" alt="ْ" class="charimage"></td>
+          <tr id="def_U+0652">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+0652.svg" alt="ْ" class="charimage"></td>
 
-          <td class="uname">U+0652</td>
+            <td class="uname">U+0652</td>
 
-          <td class="uname">ARABIC SUKUN</td>
+            <td class="uname">ARABIC SUKUN</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+0653">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+0653.svg" alt="ٓ" class="charimage"></td>
+          <tr id="def_U+0653">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+0653.svg" alt="ٓ" class="charimage"></td>
 
-          <td class="uname">U+0653</td>
+            <td class="uname">U+0653</td>
 
-          <td class="uname">ARABIC MADDAH ABOVE</td>
+            <td class="uname">ARABIC MADDAH ABOVE</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+0654">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+0654.svg" alt="ٔ" class="charimage"></td>
+          <tr id="def_U+0654">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+0654.svg" alt="ٔ" class="charimage"></td>
 
-          <td class="uname">U+0654</td>
+            <td class="uname">U+0654</td>
 
-          <td class="uname">ARABIC HAMZA ABOVE</td>
+            <td class="uname">ARABIC HAMZA ABOVE</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0655">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+0655.svg" alt="ٕ" class="charimage"></td>
+          <tr id="def_U+0655">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+0655.svg" alt="ٕ" class="charimage"></td>
 
-          <td class="uname">U+0655</td>
+            <td class="uname">U+0655</td>
 
-          <td class="uname">ARABIC HAMZA BELOW</td>
+            <td class="uname">ARABIC HAMZA BELOW</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+0670">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+0670.svg" alt="ٰ" class="charimage"></td>
+          <tr id="def_U+0670">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+0670.svg" alt="ٰ" class="charimage"></td>
 
-          <td class="uname">U+0670</td>
+            <td class="uname">U+0670</td>
 
-          <td class="uname">ARABIC LETTER SUPERSCRIPT ALEF</td>
+            <td class="uname">ARABIC LETTER SUPERSCRIPT ALEF</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
-      </tbody>
-    </table>
+            <td class="langMark">●</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
 
-    <h3>Numeral characters</h3>
+    <section>
+      <h2>Numeral characters</h2>
 
-    <table class="characters">
-      <thead>
-        <tr>
-          <th class="charColumn">Character</th>
+      <table class="characters">
+        <thead>
+          <tr>
+            <th class="charColumn">Character</th>
 
-          <th class="ucsColumn">UCS</th>
+            <th class="ucsColumn">UCS</th>
 
-          <th class="charnameColumn">Name</th>
+            <th class="charnameColumn">Name</th>
 
-          <th class="languageColumn">Ar</th>
+            <th class="languageColumn">Ar</th>
 
-          <th class="languageColumn">Fa</th>
-        </tr>
-      </thead>
+            <th class="languageColumn">Fa</th>
+          </tr>
+        </thead>
 
-      <tbody>
-        <tr id="def_U+0660">
-          <td class="rtlTermCell" lang="ar">٠</td>
+        <tbody>
+          <tr id="def_U+0660">
+            <td class="rtlTermCell" lang="ar">٠</td>
 
-          <td class="uname">U+0660</td>
+            <td class="uname">U+0660</td>
 
-          <td class="uname">ARABIC-INDIC DIGIT ZERO</td>
+            <td class="uname">ARABIC-INDIC DIGIT ZERO</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+0661">
-          <td class="rtlTermCell" lang="ar">١</td>
+          <tr id="def_U+0661">
+            <td class="rtlTermCell" lang="ar">١</td>
 
-          <td class="uname">U+0661</td>
+            <td class="uname">U+0661</td>
 
-          <td class="uname">ARABIC-INDIC DIGIT ONE</td>
+            <td class="uname">ARABIC-INDIC DIGIT ONE</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+0662">
-          <td class="rtlTermCell" lang="ar">٢</td>
+          <tr id="def_U+0662">
+            <td class="rtlTermCell" lang="ar">٢</td>
 
-          <td class="uname">U+0662</td>
+            <td class="uname">U+0662</td>
 
-          <td class="uname">ARABIC-INDIC DIGIT TWO</td>
+            <td class="uname">ARABIC-INDIC DIGIT TWO</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+0663">
-          <td class="rtlTermCell" lang="ar">٣</td>
+          <tr id="def_U+0663">
+            <td class="rtlTermCell" lang="ar">٣</td>
 
-          <td class="uname">U+0663</td>
+            <td class="uname">U+0663</td>
 
-          <td class="uname">ARABIC-INDIC DIGIT THREE</td>
+            <td class="uname">ARABIC-INDIC DIGIT THREE</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+0664">
-          <td class="rtlTermCell" lang="ar">٤</td>
+          <tr id="def_U+0664">
+            <td class="rtlTermCell" lang="ar">٤</td>
 
-          <td class="uname">U+0664</td>
+            <td class="uname">U+0664</td>
 
-          <td class="uname">ARABIC-INDIC DIGIT FOUR</td>
+            <td class="uname">ARABIC-INDIC DIGIT FOUR</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+0665">
-          <td class="rtlTermCell" lang="ar">٥</td>
+          <tr id="def_U+0665">
+            <td class="rtlTermCell" lang="ar">٥</td>
 
-          <td class="uname">U+0665</td>
+            <td class="uname">U+0665</td>
 
-          <td class="uname">ARABIC-INDIC DIGIT FIVE</td>
+            <td class="uname">ARABIC-INDIC DIGIT FIVE</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+0666">
-          <td class="rtlTermCell" lang="ar">٦</td>
+          <tr id="def_U+0666">
+            <td class="rtlTermCell" lang="ar">٦</td>
 
-          <td class="uname">U+0666</td>
+            <td class="uname">U+0666</td>
 
-          <td class="uname">ARABIC-INDIC DIGIT SIX</td>
+            <td class="uname">ARABIC-INDIC DIGIT SIX</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+0667">
-          <td class="rtlTermCell" lang="ar">٧</td>
+          <tr id="def_U+0667">
+            <td class="rtlTermCell" lang="ar">٧</td>
 
-          <td class="uname">U+0667</td>
+            <td class="uname">U+0667</td>
 
-          <td class="uname">ARABIC-INDIC DIGIT SEVEN</td>
+            <td class="uname">ARABIC-INDIC DIGIT SEVEN</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+0668">
-          <td class="rtlTermCell" lang="ar">٨</td>
+          <tr id="def_U+0668">
+            <td class="rtlTermCell" lang="ar">٨</td>
 
-          <td class="uname">U+0668</td>
+            <td class="uname">U+0668</td>
 
-          <td class="uname">ARABIC-INDIC DIGIT EIGHT</td>
+            <td class="uname">ARABIC-INDIC DIGIT EIGHT</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+0669">
-          <td class="rtlTermCell" lang="ar">٩</td>
+          <tr id="def_U+0669">
+            <td class="rtlTermCell" lang="ar">٩</td>
 
-          <td class="uname">U+0669</td>
+            <td class="uname">U+0669</td>
 
-          <td class="uname">ARABIC-INDIC DIGIT NINE</td>
+            <td class="uname">ARABIC-INDIC DIGIT NINE</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+06F0">
-          <td class="rtlTermCell" lang="ar">۰</td>
+          <tr id="def_U+06F0">
+            <td class="rtlTermCell" lang="ar">۰</td>
 
-          <td class="uname">U+06F0</td>
+            <td class="uname">U+06F0</td>
 
-          <td class="uname">EXTENDED ARABIC-INDIC DIGIT ZERO</td>
+            <td class="uname">EXTENDED ARABIC-INDIC DIGIT ZERO</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+06F1">
-          <td class="rtlTermCell" lang="ar">۱</td>
+          <tr id="def_U+06F1">
+            <td class="rtlTermCell" lang="ar">۱</td>
 
-          <td class="uname">U+06F1</td>
+            <td class="uname">U+06F1</td>
 
-          <td class="uname">EXTENDED ARABIC-INDIC DIGIT ONE</td>
+            <td class="uname">EXTENDED ARABIC-INDIC DIGIT ONE</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+06F2">
-          <td class="rtlTermCell" lang="ar">۲</td>
+          <tr id="def_U+06F2">
+            <td class="rtlTermCell" lang="ar">۲</td>
 
-          <td class="uname">U+06F2</td>
+            <td class="uname">U+06F2</td>
 
-          <td class="uname">EXTENDED ARABIC-INDIC DIGIT TWO</td>
+            <td class="uname">EXTENDED ARABIC-INDIC DIGIT TWO</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+06F3">
-          <td class="rtlTermCell" lang="ar">۳</td>
+          <tr id="def_U+06F3">
+            <td class="rtlTermCell" lang="ar">۳</td>
 
-          <td class="uname">U+06F3</td>
+            <td class="uname">U+06F3</td>
 
-          <td class="uname">EXTENDED ARABIC-INDIC DIGIT THREE</td>
+            <td class="uname">EXTENDED ARABIC-INDIC DIGIT THREE</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+06F4">
-          <td class="rtlTermCell" lang="ar">۴</td>
+          <tr id="def_U+06F4">
+            <td class="rtlTermCell" lang="ar">۴</td>
 
-          <td class="uname">U+06F4</td>
+            <td class="uname">U+06F4</td>
 
-          <td class="uname">EXTENDED ARABIC-INDIC DIGIT FOUR</td>
+            <td class="uname">EXTENDED ARABIC-INDIC DIGIT FOUR</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+06F5">
-          <td class="rtlTermCell" lang="ar">۵</td>
+          <tr id="def_U+06F5">
+            <td class="rtlTermCell" lang="ar">۵</td>
 
-          <td class="uname">U+06F5</td>
+            <td class="uname">U+06F5</td>
 
-          <td class="uname">EXTENDED ARABIC-INDIC DIGIT FIVE</td>
+            <td class="uname">EXTENDED ARABIC-INDIC DIGIT FIVE</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+06F6">
-          <td class="rtlTermCell" lang="ar">۶</td>
+          <tr id="def_U+06F6">
+            <td class="rtlTermCell" lang="ar">۶</td>
 
-          <td class="uname">U+06F6</td>
+            <td class="uname">U+06F6</td>
 
-          <td class="uname">EXTENDED ARABIC-INDIC DIGIT SIX</td>
+            <td class="uname">EXTENDED ARABIC-INDIC DIGIT SIX</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+06F7">
-          <td class="rtlTermCell" lang="ar">۷</td>
+          <tr id="def_U+06F7">
+            <td class="rtlTermCell" lang="ar">۷</td>
 
-          <td class="uname">U+06F7</td>
+            <td class="uname">U+06F7</td>
 
-          <td class="uname">EXTENDED ARABIC-INDIC DIGIT SEVEN</td>
+            <td class="uname">EXTENDED ARABIC-INDIC DIGIT SEVEN</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+06F8">
-          <td class="rtlTermCell" lang="ar">۸</td>
+          <tr id="def_U+06F8">
+            <td class="rtlTermCell" lang="ar">۸</td>
 
-          <td class="uname">U+06F8</td>
+            <td class="uname">U+06F8</td>
 
-          <td class="uname">EXTENDED ARABIC-INDIC DIGIT EIGHT</td>
+            <td class="uname">EXTENDED ARABIC-INDIC DIGIT EIGHT</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+06F9">
-          <td class="rtlTermCell" lang="ar">۹</td>
+          <tr id="def_U+06F9">
+            <td class="rtlTermCell" lang="ar">۹</td>
 
-          <td class="uname">U+06F9</td>
+            <td class="uname">U+06F9</td>
 
-          <td class="uname">EXTENDED ARABIC-INDIC DIGIT NINE</td>
+            <td class="uname">EXTENDED ARABIC-INDIC DIGIT NINE</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
-      </tbody>
-    </table>
+            <td class="langMark">●</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
 
-    <h3>Punctuations and symbols</h3>
+    <section>
+      <h2>Punctuations and symbols</h2>
 
-    <table class="characters">
-      <thead>
-        <tr>
-          <th class="charColumn">Character</th>
+      <table class="characters">
+        <thead>
+          <tr>
+            <th class="charColumn">Character</th>
 
-          <th class="ucsColumn">UCS</th>
+            <th class="ucsColumn">UCS</th>
 
-          <th class="charnameColumn">Name</th>
+            <th class="charnameColumn">Name</th>
 
-          <th class="languageColumn">Ar</th>
+            <th class="languageColumn">Ar</th>
 
-          <th class="languageColumn">Fa</th>
-        </tr>
-      </thead>
+            <th class="languageColumn">Fa</th>
+          </tr>
+        </thead>
 
-      <tbody>
-        <tr id="def_U+00AB">
-          <td class="rtlTermCell" lang="ar">«</td>
+        <tbody>
+          <tr id="def_U+00AB">
+            <td class="rtlTermCell" lang="ar">«</td>
 
-          <td class="uname">U+00AB</td>
+            <td class="uname">U+00AB</td>
 
-          <td class="uname">LEFT-POINTING DOUBLE ANGLE QUOTATION MARK</td>
+            <td class="uname">LEFT-POINTING DOUBLE ANGLE QUOTATION MARK</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+00BB">
-          <td class="rtlTermCell" lang="ar">»</td>
+          <tr id="def_U+00BB">
+            <td class="rtlTermCell" lang="ar">»</td>
 
-          <td class="uname">U+00BB</td>
+            <td class="uname">U+00BB</td>
 
-          <td class="uname">RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK</td>
+            <td class="uname">RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+00D7">
-          <td class="rtlTermCell" lang="ar">×</td>
+          <tr id="def_U+00D7">
+            <td class="rtlTermCell" lang="ar">×</td>
 
-          <td class="uname">U+00D7</td>
+            <td class="uname">U+00D7</td>
 
-          <td class="uname">MULTIPLICATION SIGN</td>
+            <td class="uname">MULTIPLICATION SIGN</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+00F7">
-          <td class="rtlTermCell" lang="ar">÷</td>
+          <tr id="def_U+00F7">
+            <td class="rtlTermCell" lang="ar">÷</td>
 
-          <td class="uname">U+00F7</td>
+            <td class="uname">U+00F7</td>
 
-          <td class="uname">DIVISION SIGN</td>
+            <td class="uname">DIVISION SIGN</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+060C">
-          <td class="rtlTermCell" lang="ar">،</td>
+          <tr id="def_U+060C">
+            <td class="rtlTermCell" lang="ar">،</td>
 
-          <td class="uname">U+060C</td>
+            <td class="uname">U+060C</td>
 
-          <td class="uname">ARABIC COMMA</td>
+            <td class="uname">ARABIC COMMA</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+061B">
-          <td class="rtlTermCell" lang="ar">؛</td>
+          <tr id="def_U+061B">
+            <td class="rtlTermCell" lang="ar">؛</td>
 
-          <td class="uname">U+061B</td>
+            <td class="uname">U+061B</td>
 
-          <td class="uname">ARABIC SEMICOLON</td>
+            <td class="uname">ARABIC SEMICOLON</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+061F">
-          <td class="rtlTermCell" lang="ar">؟</td>
+          <tr id="def_U+061F">
+            <td class="rtlTermCell" lang="ar">؟</td>
 
-          <td class="uname">U+061F</td>
+            <td class="uname">U+061F</td>
 
-          <td class="uname">ARABIC QUESTION MARK</td>
+            <td class="uname">ARABIC QUESTION MARK</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+0640">
-          <td class="rtlTermCell" lang="ar">ـ</td>
+          <tr id="def_U+0640">
+            <td class="rtlTermCell" lang="ar">ـ</td>
 
-          <td class="uname">U+0640</td>
+            <td class="uname">U+0640</td>
 
-          <td class="uname">ARABIC TATWEEL</td>
+            <td class="uname">ARABIC TATWEEL</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+066A">
-          <td class="rtlTermCell" lang="ar">٪</td>
+          <tr id="def_U+066A">
+            <td class="rtlTermCell" lang="ar">٪</td>
 
-          <td class="uname">U+066A</td>
+            <td class="uname">U+066A</td>
 
-          <td class="uname">ARABIC PERCENT SIGN</td>
+            <td class="uname">ARABIC PERCENT SIGN</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+066B">
-          <td class="rtlTermCell" lang="ar">٫</td>
+          <tr id="def_U+066B">
+            <td class="rtlTermCell" lang="ar">٫</td>
 
-          <td class="uname">U+066B</td>
+            <td class="uname">U+066B</td>
 
-          <td class="uname">ARABIC DECIMAL SEPARATOR</td>
+            <td class="uname">ARABIC DECIMAL SEPARATOR</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+066C">
-          <td class="rtlTermCell" lang="ar">٬</td>
+          <tr id="def_U+066C">
+            <td class="rtlTermCell" lang="ar">٬</td>
 
-          <td class="uname">U+066C</td>
+            <td class="uname">U+066C</td>
 
-          <td class="uname">ARABIC THOUSANDS SEPARATOR</td>
+            <td class="uname">ARABIC THOUSANDS SEPARATOR</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+2010">
-          <td class="rtlTermCell" lang="ar">‐</td>
+          <tr id="def_U+2010">
+            <td class="rtlTermCell" lang="ar">‐</td>
 
-          <td class="uname">U+2010</td>
+            <td class="uname">U+2010</td>
 
-          <td class="uname">HYPHEN</td>
+            <td class="uname">HYPHEN</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+2013">
-          <td class="rtlTermCell" lang="ar">–</td>
+          <tr id="def_U+2013">
+            <td class="rtlTermCell" lang="ar">–</td>
 
-          <td class="uname">U+2013</td>
+            <td class="uname">U+2013</td>
 
-          <td class="uname">EN DASH</td>
+            <td class="uname">EN DASH</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+2014">
-          <td class="rtlTermCell" lang="ar">—</td>
+          <tr id="def_U+2014">
+            <td class="rtlTermCell" lang="ar">—</td>
 
-          <td class="uname">U+2014</td>
+            <td class="uname">U+2014</td>
 
-          <td class="uname">EM DASH</td>
+            <td class="uname">EM DASH</td>
 
-          <td class="langMark">●</td>
+            <td class="langMark">●</td>
 
-          <td class="langMark">✕</td>
-        </tr>
+            <td class="langMark">✕</td>
+          </tr>
 
-        <tr id="def_U+2026">
-          <td class="rtlTermCell" lang="ar">…</td>
+          <tr id="def_U+2026">
+            <td class="rtlTermCell" lang="ar">…</td>
 
-          <td class="uname">U+2026</td>
+            <td class="uname">U+2026</td>
 
-          <td class="uname">HORIZONTAL ELLIPSIS</td>
+            <td class="uname">HORIZONTAL ELLIPSIS</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+2039">
-          <td class="rtlTermCell" lang="ar">‹</td>
+          <tr id="def_U+2039">
+            <td class="rtlTermCell" lang="ar">‹</td>
 
-          <td class="uname">U+2039</td>
+            <td class="uname">U+2039</td>
 
-          <td class="uname">SINGLE LEFT-POINTING ANGLE QUOTATION MARK</td>
+            <td class="uname">SINGLE LEFT-POINTING ANGLE QUOTATION MARK</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+203A">
-          <td class="rtlTermCell" lang="ar">›</td>
+          <tr id="def_U+203A">
+            <td class="rtlTermCell" lang="ar">›</td>
 
-          <td class="uname">U+203A</td>
+            <td class="uname">U+203A</td>
 
-          <td class="uname">SINGLE RIGHT-POINTING ANGLE QUOTATION MARK</td>
+            <td class="uname">SINGLE RIGHT-POINTING ANGLE QUOTATION MARK</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+2212">
-          <td class="rtlTermCell" lang="ar">−</td>
+          <tr id="def_U+2212">
+            <td class="rtlTermCell" lang="ar">−</td>
 
-          <td class="uname">U+2212</td>
+            <td class="uname">U+2212</td>
 
-          <td class="uname">MINUS SIGN</td>
+            <td class="uname">MINUS SIGN</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">○</td>
-        </tr>
-      </tbody>
-    </table>
+            <td class="langMark">○</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
 
-    <h3>Control characters</h3>
+    <section>
+      <h2>Control characters</h2>
 
-    <table class="characters">
-      <thead>
-        <tr>
-          <th class="charColumn">Character</th>
+      <table class="characters">
+        <thead>
+          <tr>
+            <th class="charColumn">Character</th>
 
-          <th class="ucsColumn">UCS</th>
+            <th class="ucsColumn">UCS</th>
 
-          <th class="charnameColumn">Name</th>
+            <th class="charnameColumn">Name</th>
 
-          <th class="languageColumn">Ar</th>
+            <th class="languageColumn">Ar</th>
 
-          <th class="languageColumn">Fa</th>
-        </tr>
-      </thead>
+            <th class="languageColumn">Fa</th>
+          </tr>
+        </thead>
 
-      <tbody>
-        <tr id="def_U+200C">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+200C.svg" alt="‌" class="charimage"></td>
+        <tbody>
+          <tr id="def_U+200C">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+200C.svg" alt="‌" class="charimage"></td>
 
-          <td class="uname">U+200C</td>
+            <td class="uname">U+200C</td>
 
-          <td class="uname">ZERO WIDTH NON-JOINER</td>
+            <td class="uname">ZERO WIDTH NON-JOINER</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+200D">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+200D.svg" alt="‍" class="charimage"></td>
+          <tr id="def_U+200D">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+200D.svg" alt="‍" class="charimage"></td>
 
-          <td class="uname">U+200D</td>
+            <td class="uname">U+200D</td>
 
-          <td class="uname">ZERO WIDTH JOINER</td>
+            <td class="uname">ZERO WIDTH JOINER</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+200E">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+200E.svg" alt="‎" class="charimage"></td>
+          <tr id="def_U+200E">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+200E.svg" alt="‎" class="charimage"></td>
 
-          <td class="uname">U+200E</td>
+            <td class="uname">U+200E</td>
 
-          <td class="uname">LEFT-TO-RIGHT MARK</td>
+            <td class="uname">LEFT-TO-RIGHT MARK</td>
 
-          <td class="langMark">○</td>
+            <td class="langMark">○</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+200F">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+200F.svg" alt="‏" class="charimage"></td>
+          <tr id="def_U+200F">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+200F.svg" alt="‏" class="charimage"></td>
 
-          <td class="uname">U+200F</td>
+            <td class="uname">U+200F</td>
 
-          <td class="uname">RIGHT-TO-LEFT MARK</td>
+            <td class="uname">RIGHT-TO-LEFT MARK</td>
 
-          <td class="langMark">○</td>
+            <td class="langMark">○</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+2028">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+2028.svg" alt=" " class="charimage"></td>
+          <tr id="def_U+2028">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+2028.svg" alt=" " class="charimage"></td>
 
-          <td class="uname">U+2028</td>
+            <td class="uname">U+2028</td>
 
-          <td class="uname">LINE SEPARATOR</td>
+            <td class="uname">LINE SEPARATOR</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+2029">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+2029.svg" alt=" " class="charimage"></td>
+          <tr id="def_U+2029">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+2029.svg" alt=" " class="charimage"></td>
 
-          <td class="uname">U+2029</td>
+            <td class="uname">U+2029</td>
 
-          <td class="uname">PARAGRAPH SEPARATOR</td>
+            <td class="uname">PARAGRAPH SEPARATOR</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+202A">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+202A.svg" alt="‪" class="charimage"></td>
+          <tr id="def_U+202A">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+202A.svg" alt="‪" class="charimage"></td>
 
-          <td class="uname">U+202A</td>
+            <td class="uname">U+202A</td>
 
-          <td class="uname">LEFT-TO-RIGHT EMBEDDING</td>
+            <td class="uname">LEFT-TO-RIGHT EMBEDDING</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+202B">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+202B.svg" alt="‫" class="charimage"></td>
+          <tr id="def_U+202B">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+202B.svg" alt="‫" class="charimage"></td>
 
-          <td class="uname">U+202B</td>
+            <td class="uname">U+202B</td>
 
-          <td class="uname">RIGHT-TO-LEFT EMBEDDING</td>
+            <td class="uname">RIGHT-TO-LEFT EMBEDDING</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+202C">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+202C.svg" alt="‬" class="charimage"></td>
+          <tr id="def_U+202C">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+202C.svg" alt="‬" class="charimage"></td>
 
-          <td class="uname">U+202C</td>
+            <td class="uname">U+202C</td>
 
-          <td class="uname">POP DIRECTIONAL FORMATTING</td>
+            <td class="uname">POP DIRECTIONAL FORMATTING</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+202D">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+202D.svg" alt="‭" class="charimage"></td>
+          <tr id="def_U+202D">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+202D.svg" alt="‭" class="charimage"></td>
 
-          <td class="uname">U+202D</td>
+            <td class="uname">U+202D</td>
 
-          <td class="uname">LEFT-TO-RIGHT OVERRIDE</td>
+            <td class="uname">LEFT-TO-RIGHT OVERRIDE</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+202E">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+202E.svg" alt="‮" class="charimage"></td>
+          <tr id="def_U+202E">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+202E.svg" alt="‮" class="charimage"></td>
 
-          <td class="uname">U+202E</td>
+            <td class="uname">U+202E</td>
 
-          <td class="uname">RIGHT-TO-LEFT OVERRIDE</td>
+            <td class="uname">RIGHT-TO-LEFT OVERRIDE</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+2060">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+2060.svg" alt="⁠" class="charimage"></td>
+          <tr id="def_U+2060">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+2060.svg" alt="⁠" class="charimage"></td>
 
-          <td class="uname">U+2060</td>
+            <td class="uname">U+2060</td>
 
-          <td class="uname">WORD JOINER</td>
+            <td class="uname">WORD JOINER</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
+            <td class="langMark">●</td>
+          </tr>
 
-        <tr id="def_U+2066">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+2066.svg" alt="⁦" class="charimage"></td>
+          <tr id="def_U+2066">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+2066.svg" alt="⁦" class="charimage"></td>
 
-          <td class="uname">U+2066</td>
+            <td class="uname">U+2066</td>
 
-          <td class="uname">LEFT-TO-RIGHT ISOLATE</td>
+            <td class="uname">LEFT-TO-RIGHT ISOLATE</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+2067">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+2067.svg" alt="⁧" class="charimage"></td>
+          <tr id="def_U+2067">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+2067.svg" alt="⁧" class="charimage"></td>
 
-          <td class="uname">U+2067</td>
+            <td class="uname">U+2067</td>
 
-          <td class="uname">RIGHT-TO-LEFT ISOLATE</td>
+            <td class="uname">RIGHT-TO-LEFT ISOLATE</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+2068">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+2068.svg" alt="⁨" class="charimage"></td>
+          <tr id="def_U+2068">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+2068.svg" alt="⁨" class="charimage"></td>
 
-          <td class="uname">U+2068</td>
+            <td class="uname">U+2068</td>
 
-          <td class="uname">FIRST STRONG ISOLATE</td>
+            <td class="uname">FIRST STRONG ISOLATE</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+2069">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+2069.svg" alt="⁩" class="charimage"></td>
+          <tr id="def_U+2069">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+2069.svg" alt="⁩" class="charimage"></td>
 
-          <td class="uname">U+2069</td>
+            <td class="uname">U+2069</td>
 
-          <td class="uname">POP DIRECTIONAL ISOLATE</td>
+            <td class="uname">POP DIRECTIONAL ISOLATE</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">○</td>
-        </tr>
+            <td class="langMark">○</td>
+          </tr>
 
-        <tr id="def_U+FEFF">
-          <td class="rtlTermCell" lang="ar"><img src="images/characters/U+FEFF.svg" alt="﻿" class="charimage"></td>
+          <tr id="def_U+FEFF">
+            <td class="rtlTermCell" lang="ar"><img src="images/characters/U+FEFF.svg" alt="﻿" class="charimage"></td>
 
-          <td class="uname">U+FEFF</td>
+            <td class="uname">U+FEFF</td>
 
-          <td class="uname">ZERO WIDTH NO-BREAK SPACE</td>
+            <td class="uname">ZERO WIDTH NO-BREAK SPACE</td>
 
-          <td class="langMark">✕</td>
+            <td class="langMark">✕</td>
 
-          <td class="langMark">●</td>
-        </tr>
-      </tbody>
-    </table>
+            <td class="langMark">●</td>
+          </tr>
+        </tbody>
+      </table>
 
-    <p>Unicode 6.3 introduced directional isolate characters to replace the more complicated directional embedding characters. These new characters are in the process of being supported in applications and their usage is encouraged over the old embedding characters. <span class="uname">U+202A LEFT-TO-RIGHT EMBEDDING</span>, <span class="uname">U+202B RIGHT-TO-LEFT EMBEDDING</span>, <span class="uname">U+202C POP DIRECTIONAL FORMATTING</span>, <span class="uname">U+202D LEFT-TO-RIGHT OVERRIDE</span>, <span class="uname">U+202E RIGHT-TO-LEFT OVERRIDE</span> are the old embedding characters and <span class="uname">U+2066 LEFT‑TO‑RIGHT ISOLATE</span>, <span class="uname">U+2067 RIGHT‑TO‑LEFT ISOLATE</span>, <span class="uname">U+2068 FIRST STRONG ISOLATE</span>, and <span class="uname">U+2069 POP DIRECTIONAL ISOLATE</span> are the new isolate characters.</p>
+      <p>Unicode 6.3 introduced directional isolate characters to replace the more complicated directional embedding characters. These new characters are in the process of being supported in applications and their usage is encouraged over the old embedding characters. <span class="uname">U+202A LEFT-TO-RIGHT EMBEDDING</span>, <span class="uname">U+202B RIGHT-TO-LEFT EMBEDDING</span>, <span class="uname">U+202C POP DIRECTIONAL FORMATTING</span>, <span class="uname">U+202D LEFT-TO-RIGHT OVERRIDE</span>, <span class="uname">U+202E RIGHT-TO-LEFT OVERRIDE</span> are the old embedding characters and <span class="uname">U+2066 LEFT‑TO‑RIGHT ISOLATE</span>, <span class="uname">U+2067 RIGHT‑TO‑LEFT ISOLATE</span>, <span class="uname">U+2068 FIRST STRONG ISOLATE</span>, and <span class="uname">U+2069 POP DIRECTIONAL ISOLATE</span> are the new isolate characters.</p>
 
-    <p>Also, character <span class="uname">U+FEFF ZERO WIDTH NO-BREAK SPACE</span> is deprecated and should be replaced with <span class="uname">U+2060 WORD JOINER</span>.</p>
+      <p>Also, character <span class="uname">U+FEFF ZERO WIDTH NO-BREAK SPACE</span> is deprecated and should be replaced with <span class="uname">U+2060 WORD JOINER</span>.</p>
+    </section>
   </section>
 
   <section class="appendix" id="glossary">

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
     <h2>Introduction</h2>
 
     <section id="h_about_this_document">
-      <h2>About this document</h2>
+      <h3>About this document</h3>
 
       <p>Some text goes here.</p>
     </section>
@@ -114,7 +114,7 @@
     </ul>
 
     <section id="h_encoding">
-      <h2>Encoding</h2>
+      <h3>Encoding</h3>
 
       <p>Arabic script is encoded in the Unicode standard <em>semantically</em>, meaning that every letter receives only a single Unicode character, no matter how many different contextual shapes it may exhibit.</p>
 
@@ -122,7 +122,7 @@
     </section>
 
     <section id="h_direction">
-      <h2>Direction</h2>
+      <h3>Direction</h3>
 
       <p>Arabic script is written from right to left. Numbers, even Arabic numbers, are written from left to right, as is text in a script that is normally left-to-right.</p>
 
@@ -174,10 +174,10 @@
     </section>
 
     <section id="h_joining">
-      <h2>Joining</h2>
+      <h3>Joining</h3>
 
       <section id="h_joining_behavior_of_characters">
-        <h2>Joining Behavior of Characters</h2>
+        <h4>Joining Behavior of Characters</h4>
 
         <p>Arabic script is cursive; i.e, characters are joined to their neighbors. For this purpose, each Arabic letter has at most four different shapes that allows it to join to its neighbors: beside the <span class="qterm">isolated</span> form, there are <span class="qterm">initial</span>, <span class="qterm">medial</span>, and <span class="qterm">final</span> forms. Their purposes, as their names suggest, are as follows:</p>
 
@@ -220,14 +220,14 @@
         <p>Please refer to The Unicode Standard Version 8.0, Section 9.2, for full explanation of Arabic cursive joining.</p>
 
         <section id="h_joining_and_spacing">
-          <h2>Joining and Intra-Word Spaces</h2>
+          <h5>Joining and Intra-Word Spaces</h5>
 
           <p>The only spaces inside Arabic words are created near characters that are not dual-joining. When adjusing intra-word spaces (i.e. the space inside the words) only these spaces can be adjusted. Moving two joined characters closer to or further from each other creates undesirable results.</p>
         </section>
       </section>
 
       <section id="h_ligatures">
-        <h2>Ligatures</h2>
+        <h4>Ligatures</h4>
 
         <p>Almost all the writing styles of Arabic script use a special shape when letters <span class="lettername">lam</span> and <span class="lettername">alef</span> are joined. Most Arabic fonts include mandatory ligatures for this combination. Ignoring this ligature, as shown in , leads to wrong rendering of text.</p>
 
@@ -242,10 +242,10 @@
     </section>
 
     <section id="h_font_and_typographical_considerations">
-      <h2><a href="#h_font_and_typographical_considerations">Font and Typographical considerations</a></h2>
+      <h3><a href="#h_font_and_typographical_considerations">Font and Typographical considerations</a></h3>
 
       <section id="h_arabic_style_and_calligraphy">
-        <h2>Arabic Style and Calligraphy</h2>
+        <h4>Arabic Style and Calligraphy</h4>
 
         <p>Arabic styling and writing has its origins in Islamic art and civilization, and was widely used to decorate mosques and palaces, as well as to create beautiful manuscripts and books, and especially to copy the <em>Kor'an</em>. Arabic script is cursive, making it viable to support different geometric shapes overlapping and composition. Words can be written in a very condensed form as well as stretched into elongated shapes, and the scribes and artists of Islam labored with passion to take advantage of all these possibilities.</p>
 
@@ -258,7 +258,7 @@
       </section>
 
       <section id="h_different_writing_styles">
-        <h2>Different Writing Styles</h2>
+        <h4>Different Writing Styles</h4>
 
         <p>Basics and principles of Arabic writing were defined by <em>Ibn Moqlah</em> (886-940 Higra), who defined six styles of writing: <em>Kufi</em>, <em>Thuluth</em>, <em>Naskh</em>, <em>Ruqʻa</em>, <em>Taʻliq</em> and <em>Diwani</em>.</p>
 
@@ -358,7 +358,7 @@
       </section>
 
       <section id="h_arabic_script_and_typography">
-        <h2>Arabic Script and Typography</h2>
+        <h4>Arabic Script and Typography</h4>
 
         <p>Arabic script has some characteristics that are challenging for typographers and font designers. Examples bellow show some characteristics worth to be considered carefully. How could typography, which came late to the Arabic world, then follow the tradition of the many authors and artists who manually shaped the Arabic writing over decades? even in it's simplest <span style="font-style: italic;">Naskh</span> style?</p>
 
@@ -484,7 +484,7 @@
       </section>
 
       <section id="h_fonts">
-        <h2>Fonts</h2>
+        <h4>Fonts</h4>
 
         <p>Arabic script counts 26 letters, and mostly 19 basic shapes. Since letters change according to their position in the word, Arabic set of glyph may range to more than one hundred shapes. If one count possible ligatures, and different combination of joining forms (see above), the number of glyph can increase further. Not sure that typeface design can accommodate all needs, even though some present typefaces can run hundred of shapes.</p>
 
@@ -513,7 +513,7 @@
     <h2><a href="#h_characters_and_words">Characters and Words</a></h2>
 
     <section id="h_diacritics">
-      <h2><a href="#h_diacritics">Diacritics</a></h2>
+      <h3><a href="#h_diacritics">Diacritics</a></h3>
 
       <p>In Arabic script text it is unusual to use diacritics for vowel information and for consonant lengthening.</p>
 
@@ -549,7 +549,7 @@
     <h2><a href="#h_lines_and_paragraphs">Lines and Paragraphs</a></h2>
 
     <section id="h_line_breaking">
-      <h2><a href="#h_line_breaking">Line breaking</a></h2>
+      <h3><a href="#h_line_breaking">Line breaking</a></h3>
 
       <p>When Arabic text doesn't fit within the available line width, the text is wrapped to the next line between words.</p>
 
@@ -786,7 +786,7 @@
     </section>
 
     <section id="h_para_line_alignment">
-      <h2><a href="#h_para_line_alignment">Paragraph and line alignment</a></h2>
+      <h3><a href="#h_para_line_alignment">Paragraph and line alignment</a></h3>
 
       <p>Lines of Arabic script text are normally right aligned within the page.</p>
 
@@ -888,7 +888,7 @@
     <p>The following tables list Unicode characters used for Arabic script, excluding ASCII. Each table has two columns named <span class="qterm">Ar</span> and <span class="qterm">Fa</span> which denote which characters are used for Arabic or Persian languages, respectively. A black circle (●) under each of these two columns means that a character is used for that language. A white circle (○) denotes a character that is auxiliary for that language. An X mark (✕) means the character is not used for that langauge.</p>
 
     <section id="h_character_tables_alphabetical_characters">
-      <h2>Alphabetical characters</h2>
+      <h3>Alphabetical characters</h3>
 
       <table class="characters">
         <thead>
@@ -1510,7 +1510,7 @@
     </section>
 
     <section id="h_character_tables_diacritics">
-      <h2>Diacritics</h2>
+      <h3>Diacritics</h3>
 
       <table class="characters">
         <thead>
@@ -1676,7 +1676,7 @@
     </section>
 
     <section id="h_character_tables_numeral_characters">
-      <h2>Numeral characters</h2>
+      <h3>Numeral characters</h3>
 
       <table class="characters">
         <thead>
@@ -1938,7 +1938,7 @@
     </section>
 
     <section id="h_character_tables_punctuations_and_symbols">
-      <h2>Punctuations and symbols</h2>
+      <h3>Punctuations and symbols</h3>
 
       <table class="characters">
         <thead>
@@ -2176,7 +2176,7 @@
     </section>
 
     <section id="h_character_tables_control_characters">
-      <h2>Control characters</h2>
+      <h3>Control characters</h3>
 
       <table class="characters">
         <thead>


### PR DESCRIPTION
Had to close #71 because of a conflict. This is a new version of that. See that and #69 for discussion.

This commit now makes all titles follow what we agreed upon on those discussions, which is:
- Start with `h2` for each top-level section and go through smaller titles (`h3`, `h4`, …) for deeper sections.
- Remove the occasional styles applied locally to titles.
- Add `id`s to all sections.
- Remove links to selves from headers.
