### PR TITLE
Fixed typos and removed some synonyms

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,11 +227,11 @@
       <section id="h_arabic_style_and_calligraphy">
         <h4>Arabic Style and Calligraphy</h4>
 
-        <p>Arabic styling and writing has its origins in Islamic art and civilization, and was widely used to decorate mosques and palaces, as well as to create beautiful manuscripts and books, and especially to copy the <em>Kor'an</em>. Arabic script is cursive, making it viable to support different geometric shapes overlapping and composition. Words can be written in a very condensed form as well as stretched into elongated shapes, and the scribes and artists of Islam labored with passion to take advantage of all these possibilities.</p>
+        <p>Arabic styling and writing has its origins in Islamic art and civilization, and was widely used to decorate mosques and palaces, as well as to create beautiful manuscripts and books, and especially to copy the <em>Korʼan</em>. Arabic script is cursive, making it viable to support different geometric shapes overlapping and composition. Words can be written in a very condensed form as well as stretched into elongated shapes, and the scribes and artists of Islam labored with passion to take advantage of all these possibilities.</p>
 
-        <p>From the beginning of Arabic calligraphy, two tendencies or two types of styles can be seen emerging: writing for the decoration of mosques and sculptures, which was complex and highly decorative, and writing styles reserved for writing the <em>Kor'an</em>, which were easier to use and more readable.</p>
+        <p>From the beginning of Arabic calligraphy, two tendencies or two types of styles can be seen emerging: writing for the decoration of mosques and sculptures, which was complex and highly decorative, and writing styles reserved for writing the <em>Korʼan</em>, which were easier to use and more readable.</p>
 
-        <p>Writing styles then evolved under the influences of cultural diversity, leading to regional calligraphic schools and styles (<em>Kufi</em> in Iraq, <em>Farsi</em> and <em>Taʻliq</em> in Persia, or <em>Diwani</em> in Turkey). Additional differences arose depending on the purpose of writing, such as the copying and dissemination of the <em>Korʼan</em>.</p>
+        <p>Writing styles then evolved under the influences of cultural diversity, leading to regional calligraphic schools and styles (<em>Kufi</em> in Iraq, <em>Farsi</em> and <em>Taʻlīq</em> in Persia, or <em>Diwani</em> in Turkey). Additional differences arose depending on the purpose of writing, such as the copying and dissemination of the <em>Korʼan</em>.</p>
 
         <p>In general we group under the generic term <em><strong>Naskh</strong></em> (copy/inscription) the scripts which are meant for reading at smaller sizes and are suitable for books and texts to be read, e.g. the <em>Korʼan</em>, and as <em><strong>Kufic</strong></em> the highly stylized font styles used for ornamentation and more styled writings. Nevertheless, the rich evolution of the Arabic script led to the distinctive enumeration of a number of additional named styles.<br>
         Two other styles are used as synonyms for <em>Kufic</em> and <em>Naskh</em>: <em>Mabsut</em> (<em>wa mustaqīm</em>) is a form of style that is straight angled and elongated, [which dominated the copies of <em>Korʼan</em> in eighth and ninth centuries], and <em>Muqawwar</em> (<em>wa mudawar</em>) is a form of style that is curved and rounded.</p>
@@ -240,7 +240,7 @@
       <section id="h_different_writing_styles">
         <h4>Different Writing Styles</h4>
 
-        <p>Basics and principles of Arabic writing were defined by <em>Ibn Moqlah</em> (886-940 Higra), who defined six styles of writing: <em>Kufi</em>, <em>Thuluth</em>, <em>Naskh</em>, <em>Ruqʻa</em>, <em>Taʻliq</em> and <em>Diwani</em>.</p>
+        <p>Basics and principles of Arabic writing were defined by <em>Ibn Moqlah</em> (886-940 Higra), who defined six styles of writing: <em>Kufi</em>, <em>Thuluth</em>, <em>Naskh</em>, <em>Ruqʻa</em>, <em>Taʻlīq</em> and <em>Diwani</em>.</p>
 
         <dl>
 
@@ -251,7 +251,7 @@
 	      <img style="width: 200px; height: 147px;" src="images/kufiExampleQuran.jpg" alt="Kufi script">
 	      <figcaption>Kufi example [<a href="https://commons.wikimedia.org/wiki/File:A_section_of_the_Koran_-_Google_Art_Project.jpg">Source</a>].</figcaption>
 	    </figure>
-	      <p>One of the oldest and best known Arabic scripts. It is characterized by its decorative and pronounced geometric forms, well adapted for architectural designs. The style grew with the beginning of Islam to satisfy a need for Muslims to codify the Kor'an.</p>
+	      <p>One of the oldest and best known Arabic scripts. It is characterized by its decorative and pronounced geometric forms, well adapted for architectural designs. The style grew with the beginning of Islam to satisfy a need for Muslims to codify the Korʼan.</p>
           </dd>
 
           <dt>Thuluth (ثلث)</dt>
@@ -272,14 +272,14 @@
 	      <img style="width: 147px; height: 166px;" src="images/naskhQuran2.png" alt="Naskh script">
 	      <figcaption>Nask example [<a href="https://commons.wikimedia.org/wiki/File:FirstSurahKoran_%28fragment%29.jpg">Source</a>].</figcaption>
 	    </figure>
-        <p>One of the clearest styles of all, with clearly distinguished letters which facilitate reading and pronunciation. Can be written at small sizes (traditionally using pens made of reeds and ink), which suits the production of longer texts used for boards and books intended for the general population, especially the Kor'an.</p>
+        <p>One of the clearest styles of all, with clearly distinguished letters which facilitate reading and pronunciation. Can be written at small sizes (traditionally using pens made of reeds and ink), which suits the production of longer texts used for boards and books intended for the general population, especially the Korʼan.</p>
           </dd>
 
           <dt>Ruqʻa (رقعة‎)</dt>
 
           <dd class="flexContainer">
 	    <figure class="floatedFigure">
-	      <img style="width: 129px; height: 168px;" src="images/Ruq_ah.gif" alt="Ruq'a script">
+	      <img style="width: 129px; height: 168px;" src="images/Ruq_ah.gif" alt="Ruqʻa script">
 	      <figcaption>Ruqʻa example [<a href="https://fa.wikipedia.org/wiki/پرونده:Ruq_ah.gif">Source</a>].</figcaption>
 	    </figure>
 	      <p>A handwritten style still commonly used in Arabic countries, and recognisable by its bold-like letters written above the writing line. Designed to be used for education, for everyday writing and adopted in the offices (<em>Diwan</em>) of the Ottoman Empire. One of it's feature is that calligraphers have kept it and did not derived variations from it.</p>
@@ -289,11 +289,11 @@
 
           <dd class="flexContainer">
 	    <figure class="floatedFigure">
-	    <img style="width: 130px; height: 200px;" src="images/taliq.jpg" alt="Ta'liq script">
+	    <img style="width: 130px; height: 200px;" src="images/taliq.jpg" alt="Taʻlīq script">
 	      <figcaption>Taʻlīq example [<a href="https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Ta'liq_script_1.jpg/389px-Ta'liq_script_1.jpg">Source</a>].</figcaption>
 	    </figure>
 
-	    <p>Also known as <em>Farsi</em> (Iran), <em>Taʻlīq</em> (hanging). A beautiful script characterized by the precision and stretch of its letters, its clarity, and its lack of complexity. Designed for Persian language, until replaced by <em>Nastaʻlīq</em>.</p>
+	    <p><em>Taʻlīq</em> (hanging) is a beautiful script characterized by the precision and stretch of its letters, its clarity, and its lack of complexity. Designed for Persian language, until replaced by <em>Nastaʻlīq</em>.</p>
         </dd>
 
           <dt>Diwani (ديواني)</dt>
@@ -310,18 +310,18 @@
         <p>We can add other font styles to this list, such as the following :</p>
 
         <dl>
-          <dt>Nastaʻliq (نستعلیق)</dt>
+          <dt>Nastaʻlīq (نستعلیق)</dt>
 
           <dd class="flexContainer">
 	    <figure class="floatedFigure">
 	      <img style="width: 130px; height: 130px;" src="images/nastaliq.jpg" alt="Nastaliq script">
-	      <figcaption>Nastaʻliq example [<a href="https://commons.wikimedia.org/wiki/File:Khatt-e_Nastaliq.jpg">Source</a>].</figcaption>
+	      <figcaption>Nastaʻlīq example [<a href="https://commons.wikimedia.org/wiki/File:Khatt-e_Nastaliq.jpg">Source</a>].</figcaption>
 	    </figure>
 
-	      <p>Persian version of <em>Taʻliq</em>, derived from <em>Naskh</em> and <em>Taaʻliq</em> and developed in the 8th and 9th centuries. It is like a <em>Taaʻliq</em> but easier to write and read. <em>Shekasteh Nastaʻliq</em> (literally means "broken Nastaʻliq") is also another derivation of those two, developed in the 15th century.</p>
+	      <p>Persian version of <em>Taʻlīq</em>, derived from <em>Naskh</em> and <em>Taʻlīq</em> and developed in the 8th and 9th centuries. It is like a <em>Taʻlīq</em> but easier to write and read. <em>Shekasteh Nastaʻlīq</em> (literally means "broken Nastaʻlīq") is also another derivation of those two, developed in the 15th century.</p>
           </dd>
 
-          <dt>Rabat aka Maghribi (رباط او مغربي‎)</dt>
+          <dt>Maghribi (مغربي)</dt>
 
           <dd class="flexContainer">
 	    <figure class="floatedFigure">
@@ -329,7 +329,7 @@
 	      <figcaption>Maghribi example [<a href="https://commons.wikimedia.org/wiki/File:Maghribi_script_sura_5.jpg">Source</a>].</figcaption>
 	    </figure>
 
-	      <p>Western Islamic world of North Africa and Spain. Used for writing the Kor'an as well as other scientific, legal and religious manuscripts. Used in some very official printings in Morocco.</p>
+	      <p>Used in the past in the western islamic world (Andalusia), and still now in North Africa. Used for writing the Korʼan as well as other scientific, legal and religious manuscripts. <em>Rabat</em>, a mabsut version of it, is widely used in some official printings in Morocco.</p>
           </dd>
         </dl>
 
@@ -718,7 +718,7 @@
 
             <li>Is the tatweel character useful?</li>
 
-            <li>What should happen if an application uses a ruq'ah font as a fallback, which cannot allow for word elongation? Does the application need to automatically know that it should not stretch words when using this font style?</li>
+            <li>What should happen if an application uses a Ruqʻah font as a fallback, which cannot allow for word elongation? Does the application need to automatically know that it should not stretch words when using this font style?</li>
 
             <li>How does an application or person decide which methods to use, and where, to justify text?</li>
 


### PR DESCRIPTION
s/Kor'an/Korʼan/
s/ Taʻliq/ Taʻlīq/
Removed Farsi in "Taʻlīq aka Farsi"
Same for Rabat in Maghrebi example.
