### PR TITLE
mabsut term in italic with a link to glossary

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,7 +257,7 @@
         <p>Writing styles then evolved under the influences of cultural diversity, leading to regional calligraphic schools and styles (<em>Kufi</em> in Iraq, <em>Farsi</em> and <em>Taʻlīq</em> in Persia, or <em>Diwani</em> in Turkey). Additional differences arose depending on the purpose of writing, such as the copying and dissemination of the <em>Korʼan</em>.</p>
 
         <p>In general we group under the generic term <em><strong>Naskh</strong></em> (copy/inscription) the scripts which are meant for reading at smaller sizes and are suitable for books and texts to be read, e.g. the <em>Korʼan</em>, and as <em><strong>Kufic</strong></em> the highly stylized font styles used for ornamentation and more styled writings. Nevertheless, the rich evolution of the Arabic script led to the distinctive enumeration of a number of additional named styles.<br>
-        Two other styles are used as synonyms for <em>Kufic</em> and <em>Naskh</em>: <em>Mabsut</em> (<em>wa mustaqīm</em>) is a form of style that is straight angled and elongated, [which dominated the copies of <em>Korʼan</em> in eighth and ninth centuries], and <em>Muqawwar</em> (<em>wa mudawar</em>) is a form of style that is curved and rounded.</p>
+        Similarly, two other generic terms are used to classify styles : <em>Mabsut</em> (<em>wa Mustaqīm</em>) is a form of style that is elongated and straight angled, [which dominated the copies of <em>Korʼan</em> in eighth and ninth centuries], and <em>Muqawwar</em> (<em>wa Mudawwar</em>) is a form of style that is curved and rounded.</p>
       </section>
 
       <section id="h_different_writing_styles">
@@ -352,7 +352,7 @@
 	      <figcaption>Maghribi example [<a href="https://commons.wikimedia.org/wiki/File:Maghribi_script_sura_5.jpg">Source</a>].</figcaption>
 	    </figure>
 
-	      <p>Used in the past in the western islamic world (Andalusia), and still now in North Africa. Used for writing the Korʼan as well as other scientific, legal and religious manuscripts. <em>Rabat</em>, a mabsut version of it, is widely used in some official printings in Morocco.</p>
+	      <p>Used in the past in the western islamic world (Andalusia), and still now in North Africa. Used for writing the Korʼan as well as other scientific, legal and religious manuscripts. <em>Rabat</em>, a <em><a href="#def_mabsut">mabsut</a></em> version of it, is widely used in some official printings in Morocco.</p>
           </dd>
         </dl>
 


### PR DESCRIPTION
Following our discussion, "mabsut" is in italic and links to the glossary.
`<em><a href="#def_mabsut">mabsut</a></em>`
This entry is not yet put into HTML version.
