### PR TITLE
Use HTTPS for w3.org and github.io links

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       noRecTrack:           true,
       shortName:            "alreq",
       copyrightStart:       "2015",
-      edDraftURI:           "http://w3c.github.io/alreq/",
+      edDraftURI:           "https://w3c.github.io/alreq/",
 
       // if this is a LCWD, uncomment and set the end of its review period
       // lcEnd: "2009-08-05",
@@ -34,7 +34,7 @@
 
 
       wg:           "Internationalization Working Group",
-      wgURI:        "http://www.w3.org/International/core/",
+      wgURI:        "https://www.w3.org/International/core/",
       wgPublicList: "public-i18n-arabic",
       bugTracker: { new: "https://github.com/w3c/alreq/issues", open: "https://github.com/w3c/alreq/issues" } ,
       otherLinks: [
@@ -54,7 +54,7 @@
       // This is important for Rec-track documents, do not copy a patent URI from a random
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
-      wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/32113/status",
+      wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/32113/status",
       // !!!! IMPORTANT !!!! MAKE THE ABOVE BLINK IN YOUR HEAD
     };
   </script>
@@ -69,12 +69,12 @@
   <div id="sotd">
     <p>This document describes the basic requirements for Arabic script layout and text support on the Web and in eBooks. These requirements provide information for Web technologies such as CSS, HTML and digital publications about how to support users of Arabic scripts. Currently the document focuses on Standard Arabic and Persian.</p>
 
-    <p>The editor's draft of this document is being developed by the <a href="http://www.w3.org/International/groups/arabic-layout/">Arabic Layout Task Force</a>, part of the W3C <a href="http://www.w3.org/International/ig/">Internationalization Interest Group</a>. It is published by the <a href="http://www.w3.org/International/core/">Internationalization Working Group</a>. The end target for this document is a Working Group Note.</p>
+    <p>The editor's draft of this document is being developed by the <a href="https://www.w3.org/International/groups/arabic-layout/">Arabic Layout Task Force</a>, part of the W3C <a href="https://www.w3.org/International/ig/">Internationalization Interest Group</a>. It is published by the <a href="https://www.w3.org/International/core/">Internationalization Working Group</a>. The end target for this document is a Working Group Note.</p>
 
     <div class="note">
       <p data-lang="en" style="font-weight: bold; font-size: 120%">Sending comments on this document</p>
 
-      <p data-lang="en">If you wish to make comments regarding this document, please raise them as <a href="https://github.com/w3c/alreq/issues" style="font-size: 120%;">github issues</a> <!--against the <a href="http://www.w3.org/TR/2015/WD-ilreq-20150721/" style="font-size: 120%">latest dated version in /TR</a>-->. Only send comments by email if you are unable to raise issues on github (see links below). All comments are welcome.</p>
+      <p data-lang="en">If you wish to make comments regarding this document, please raise them as <a href="https://github.com/w3c/alreq/issues" style="font-size: 120%;">github issues</a> <!--against the <a href="https://www.w3.org/TR/2015/WD-ilreq-20150721/" style="font-size: 120%">latest dated version in /TR</a>-->. Only send comments by email if you are unable to raise issues on github (see links below). All comments are welcome.</p>
 
       <p data-lang="en">To make it easier to track comments, please raise separate issues or emails for each comment, and point to the section you are commenting on&nbsp; using a URL for the dated version of the document.</p>
     </div>
@@ -118,7 +118,7 @@
 
       <p>When the main script is Arabic, the layout and structure of pages and documents are also set from right to left.</p>
 
-      <p><a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9, Unicode Bidirectional Algorithm</a> details an algorithm for rendering right-to-left text and covers a myriad of situations in mixing different kinds of characters. A simpler explanation of the basics of the algorithm exists in the W3C article <a href="http://www.w3.org/International/articles/inline-bidi-markup/uba-basics">Unicode Bidirectional Algorithm basics</a>. You can refer to these documents for more information about Unicode’s bidirectional algorithm.</p>
+      <p><a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9, Unicode Bidirectional Algorithm</a> details an algorithm for rendering right-to-left text and covers a myriad of situations in mixing different kinds of characters. A simpler explanation of the basics of the algorithm exists in the W3C article <a href="https://www.w3.org/International/articles/inline-bidi-markup/uba-basics">Unicode Bidirectional Algorithm basics</a>. You can refer to these documents for more information about Unicode’s bidirectional algorithm.</p>
 
       <p>A brief overview of the bidirectional (<span class="qterm">bidi</span> for short) algorithm follows, because the direction is an essential part of how Arabic script is used.</p>
 
@@ -160,7 +160,7 @@
 
       <p>Some characters, mostly punctuations, are <span class="qterm">neutral</span>. The direction of these characters is derived from their surrounding characters. If a neutral character is surrounded by characters of the same direction (e.g. an space surrounded by Arabic letters), it gets the direction of its neighbors. Otherwise (e.g. a space between an Arabic and a Latin, or a neutral character appearing at the start or the end of a paragraph), the neutral character gets its direction from the paragraph’s base direction. This is another effect of the base direction in the bidi algorithm.</p>
 
-      <p>The above explanation of the bidi algorithm is highly simplified, to convey only the essentials of how Arabic text is transformed for rendering. The actual algorithm deals with many more character types and edge cases. Please refer to <a href="http://www.w3.org/International/articles/inline-bidi-markup/uba-basics">Unicode Bidirectional Algorithm basics</a> for more information or <a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9, Unicode Bidirectional Algorithm</a> for the official detailed documentation.</p>
+      <p>The above explanation of the bidi algorithm is highly simplified, to convey only the essentials of how Arabic text is transformed for rendering. The actual algorithm deals with many more character types and edge cases. Please refer to <a href="https://www.w3.org/International/articles/inline-bidi-markup/uba-basics">Unicode Bidirectional Algorithm basics</a> for more information or <a href="http://www.unicode.org/reports/tr9/">Unicode Standard Annex #9, Unicode Bidirectional Algorithm</a> for the official detailed documentation.</p>
     </section>
 
     <section id="h_joining">
@@ -738,7 +738,7 @@
 
           <li>Make sure “elongation,” “kashida,” and “tatweel,” have correct definitions in our glossary.</li>
 
-          <li><a href="http://www.w3.org/2016/06/28-alreq-minutes.html">Discussion at ALReq meeting on 28 June, 2016</a></li>
+          <li><a href="https://www.w3.org/2016/06/28-alreq-minutes.html">Discussion at ALReq meeting on 28 June, 2016</a></li>
 
           <li><a href="http://quod.lib.umich.edu/j/jep/3336451.0013.105?rgn=main;view=fulltext">Justify Just or Just Justify</a></li>
 


### PR DESCRIPTION
Fix one of the two new ReSpec warnings: `There are insecure URLs in your respecConfig! Please change the following properties to use 'https://': edDraftURI, wgURI, wgPatentURI.`