### PR TITLE
Corrected a typo and added Transliteration

### DIFF
--- a/index.html
+++ b/index.html
@@ -4312,7 +4312,7 @@
 
         <td lang="ar" dir="rtl">خَطْ قَاعِدِي، خَطْ الاِرْتِكَازْ، سَطْرُ الأَسَاسْ</td>
 
-          <td lang="ar-Latn-t-ar-m0-alaloc-2012">satru al-’asās, khaṭ al-irtikāz</td>
+        <td lang="ar-Latn-t-ar-m0-alaloc-2012">khaṭ qāʻidī, khaṭ al-irtikāz, satru al-’asās</td>
 
           <td lang="fa" dir="rtl">خط کرسی</td>
 
@@ -6239,9 +6239,9 @@
         <tr id="def_index">
           <td>index</td>
 
-          <td lang="ar" dir="rtl">فَهْرَسْ</td>
+        <td lang="ar" dir="rtl">فِهْرِسْ</td>
 
-          <td lang="ar-Latn-t-ar-m0-alaloc-2012">fahras</td>
+        <td lang="ar-Latn-t-ar-m0-alaloc-2012">fihris</td>
 
           <td lang="fa" dir="rtl">فهرست راهنما</td>
 
@@ -6540,7 +6540,7 @@
           <td>ligature</td>
 
         <td lang="ar" dir="rtl">رَبْطْ بَيْنَ الحُرُوفْ، تَرْكِيبْ، حَرْفْ مُرَكَّبْ</td>
-          <td lang="ar-Latn-t-ar-m0-alaloc-2012">rabṭ bayna al-ḥurūf</td>
+         <td lang="ar-Latn-t-ar-m0-alaloc-2012">rabṭ bayna al-ḥurūf, tarkīb, ḥarf murakkab</td>
 
           <td lang="fa" dir="rtl">
           </td>


### PR DESCRIPTION
"index" entry : 
s/فَهْرَسْ/فِهْرِسْ/
s/fahras/fihris/

added Arabic transliteration for entries : "baseline" and "ligature".
(Were omitted at last pull).
