### PR TITLE
Matrix code & home page update

### DIFF
--- a/gap-analysis/index.html
+++ b/gap-analysis/index.html
@@ -14,6 +14,11 @@
       //publishDate:  		"2015-07-21",
       //previousPublishDate:  "2014-12-16",
       //previousMaturity:  "FPWD",
+      
+      // langs array lists languages addressed by this document, in order of speaker (highest first)
+      // it is used to generate the javascript needed for the matrix
+      langs: ['Arabic', 'Persian'],
+      gapDocPath: 'https://w3c.github.io/alreq/gap-analysis/',
 
       noRecTrack:           true,
       shortName:            "alreq-gap",
@@ -442,6 +447,63 @@
     </section>
     
 </section>
+
+
+
+
+<details>
+<summary style="margin-top:4em; cursor: pointer;">Show summary</summary>
+<pre id="summaryPlaceholder" style="white-space: pre-wrap;"></pre>
+</details>
+<script>
+var out = ''
+for (let i=0;i<respecConfig.langs.length;i++) {
+    out += '{lang: "'+respecConfig.langs[i]+'"'
+    out += ', url:"'+respecConfig.gapDocPath+'"'
+    out += ', tentative:' + true
+    out += ', encoding:"'+document.getElementById('encoding').className+'"'   
+    out += ', fonts:"'+document.getElementById('fonts').className+'"'
+    out += ', fontstyle:"'+document.getElementById('fontstyle').className+'"'
+    out += ', glyphcontrol:"'+document.getElementById('glyphs').className+'"'
+    out += ', cursive:"'+document.getElementById('cursive').className+'"'
+    out += ', transforms:"'+document.getElementById('transforms').className+'"'
+    out += ', digits:"'+document.getElementById('numbers').className+'"'
+    out += ', boundaries:"'+document.getElementById('boundaries').className+'"'
+    out += ', quotations:"'+document.getElementById('quotations').className+'"'
+    out += ', spacing:"'+document.getElementById('spacing').className+'"'
+    out += ', ruby:"'+document.getElementById('ruby').className+'"'
+    out += ', textdecor:"'+document.getElementById('textdecoration').className+'"'
+    out += ', emphasis:"'+document.getElementById('emphasis').className+'"'
+    out += ', bidi:"'+document.getElementById('bidi').className+'"'
+    out += ', otherinline:"'+document.getElementById('otherinline').className+'"'
+    out += ', linebreak:"'+document.getElementById('linebreak').className+'"'
+    out += ', hyphenation:"'+document.getElementById('hyphenation').className+'"'
+    out += ', justification:"'+document.getElementById('justification').className+'"'
+    out += ', counters:"'+document.getElementById('counters').className+'"'
+    out += ', initialletter:"'+document.getElementById('initialletter').className+'"'
+    out += ', baselines:"'+document.getElementById('baselines').className+'"'
+    out += ', otherpara:"'+document.getElementById('otherpara').className+'"'
+    out += ', bidilayout:"'+document.getElementById('bidilayout').className+'"'
+    out += ', vertical:"'+document.getElementById('vertical').className+'"'
+    out += ', notes:"'+document.getElementById('notes').className+'"'
+    out += ', pagehead:"'+document.getElementById('pageheaders').className+'"'
+    out += ', otherpage:"'+document.getElementById('morepage').className+'"'
+    out += '},\n'
+
+    out = out.replace(/tbd/g,'')
+    out = out.replace(/ok/g,'3')
+    out = out.replace(/advanced/g,'2')
+    out = out.replace(/basic/g,'1')
+    out = out.replace(/broken/g,'0')
+    out = out.replace(/"na/g,'"-')
+    }
+document.getElementById('summaryPlaceholder').textContent = out
+
+var temp = document.querySelectorAll('section')
+for (let x=0;x<temp.length;x++) {
+    console.log(temp[x].id)
+    }
+</script>
 
 
 

--- a/homepage/index.html
+++ b/homepage/index.html
@@ -90,13 +90,9 @@ div.content { width: 100%; display: flex; flex-flow: row; flex-wrap: wrap; float
             contributor. See the  <a href="https://github.com/w3c/alreq">github home page</a> for details</li>
         </ol>
         <h2 id="admin"><a href="#admin">Organisation of the task force</a> </h2>
-        <p>The Arabic Layout Task Force is part of <a href="http://www.w3.org/International/">W3C <span class="activity">Internationalization Activity</span></a> and the <a href="http://www.w3.org/International/">W3C
-          Internationalization Interest Group</a>. </p>
-        <p>The task force  is part of the W3C Internationalization Interest Group (i18n IG). The Internationalization  Working Group (i18n WG) oversees the work of the task force, and publishes the task force's document to the TR space.
-<!--p>For more details, see the
-                    <a href="/International/its/ig/ITSIGCharter.html" rel="charter">Interest                        Group Charter</a>.</p-->
-</p>
-<p>The co-chairs of the task force are Shervin Afshar (Netflix) and Behnam Esfahbod.
+        <p>The Arabic Layout Task Force is part of the W3C <a href="http://w3c.github.io/i18n-activity/i18n-ig/">W3C
+Internationalization Interest Group</a> (i18n IG). The <a href="http://w3c.github.io/i18n-activity/i18n-wg/">Internationalization Working Group</a> (i18n WG) oversees the work of the task force, and publishes the task force's document to the TR space. </p>
+<p>The co-chairs of the task force are Shervin Afshar  and Behnam Esfahbod.
           The chair of the Interest Group is <a href="mailto:duerst@it.aoyama.ac.jp">Martin
           Dürst</a>.</p>
         <h2 id="activity"> <a href="#activity">Internationalization at W3C</a></h2>
@@ -112,12 +108,13 @@ div.content { width: 100%; display: flex; flex-flow: row; flex-wrap: wrap; float
           Recommendation-track deliverables but expects to produce Working
           Group Notes, published by the <a href="https://www.w3.org/International/core/">Internationalization
           Working Group</a>. </p>
-        <p>To find and follow progress on deliverables, see the <a href="https://github.com/w3c/hlreq">GitHub repo</a>.</p>
+        <p>To find and follow progress on deliverables, see the <a href="https://github.com/w3c/hlreq" style="font-size:120%;">GitHub repo</a>.</p>
         <p>The main deliverables include the following:</p>
 <ul>
-<li><strong>Arabic &amp; Persian gap analysis</strong></li>
+<li><strong>Arabic &amp; Persian gap analysis</strong><br>
+<a href="https://w3c.github.io/tlreq/gap-analysis">Editor's draft</a></li>
 <li><strong>Text Layout Requirements for the Arabic Script</strong><br/>
-<a href="https://w3c.github.io/alreq/">Editor's draft</a> • <a href="https://github.com/w3c/alreq/">GitHub</a></li>
+<a href="https://w3c.github.io/alreq/">Editor's draft</a></li>
 </ul>
         <p>The group <a href="https://www.w3.org/International/groups/arabic-layout/charter">charter</a> also allows review of draft specifications
           produced by other working groups, and provision of translations of


### PR DESCRIPTION
The code for the gap analysis doc allows me to quickly update the language matrix table.

This PR automatically included an additional update to the home page.  Rather than separate it, i'm hoping you're ok to merge that at the same time.