### PR TITLE
Set up Travis with HTML validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "2.7"
+addons:
+  apt:
+    packages:
+      - openjdk-8-jre  # install Java8 as required by vnu.jar
+
+install:
+ - pip install html5validator
+
+script:
+  - ./misc/scripts/validate-html.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,12 @@ addons:
     packages:
       - openjdk-8-jre  # install Java8 as required by vnu.jar
 
+notifications:
+  email:
+    on_success: never
+
 install:
- - pip install html5validator
+  - pip install html5validator
 
 script:
   - ./misc/scripts/validate-html.sh

--- a/charter/index.html
+++ b/charter/index.html
@@ -119,11 +119,10 @@ src="https://www.w3.org/Icons/w3c_home" width="72" /></a></p>
 
 <p>Plans for the main document deliverable are as follows. All deliverables will be made available in English.</p>
 
-    <table class="roadmap" width="80%"><caption>
-
-	      </caption><tfoot><tr><td colspan="4" rowspan="1">Note: The group will document significant changes from this initial schedule on the group home page</a>.</td>
-	          </tr>
-	      </tfoot><tbody><tr><th rowspan="1" colspan="1">Specification</th><!--th rowspan="1" colspan="1"><abbr title="First Working Draft">FPWD</abbr></th-->
+    <table class="roadmap" style="width: 80%">
+      <caption>
+      </caption>
+      <tbody><tr><th rowspan="1" colspan="1">Specification</th><!--th rowspan="1" colspan="1"><abbr title="First Working Draft">FPWD</abbr></th-->
             <th rowspan="1" colspan="1"><abbr title="First Public Working Draft">FPWD</abbr></th>
             <th rowspan="1" colspan="1"><abbr title="Working Draft for Final Review"> WD for final review</abbr></th>
             <th rowspan="1" colspan="1"><abbr title="Working Group Note">WG Note</abbr></th></tr>
@@ -135,7 +134,11 @@ src="https://www.w3.org/Icons/w3c_home" width="72" /></a></p>
 	            <td class="PR" rowspan="1" colspan="1">Q3 2016</td>
             <td class="REC" rowspan="1" colspan="1">Q4 2016</td></tr>
 
-</tbody></table>
+      </tbody>
+      <tfoot><tr><td colspan="4" rowspan="1">Note: The group will document significant changes from this initial schedule on the group home page.</td>
+	          </tr>
+      </tfoot>
+    </table>
     <p>Other deliverables may be produced on an ongoing basis throughout the life of the charter, and the specific topics to be addressed by the task force and schedule information cannot be determined far in advance, but are driven by the needs of the Web community.</div>
 
 <h3>Success Criteria</h3>
@@ -163,7 +166,6 @@ src="https://www.w3.org/Icons/w3c_home" width="72" /></a></p>
         <li><a href="https://www.w3.org/annotation/">Annotation Working Group</a></li>
       </ul>
     </dd>
-    <p> </P>
     <dt>Other Groups</dt>
     <dd>The Arabic Text Layout Task Force is also expected to take advantage of opportunities for discussion and collaboration with existing groups and communities in Arabic-script countries as well as groups and communities elsewhere.</dd> 
 </dl>

--- a/homepage/index.html
+++ b/homepage/index.html
@@ -58,11 +58,8 @@ div.content { width: 100%; display: flex; flex-flow: row; flex-wrap: wrap; float
 </header>
 
 
-
-
 <h1>Arabic Layout Task Force<br>
   Home Page</h1>
-</header>
 
 
 <p> <span class="intnavbar"><strong>Key information:</strong> <a href="#about">Mission</a> – <a href="../charter/">Charter</a> – <a href="https://www.w3.org/blog/International/category/alreq/">News</a> – <a href="#docs">Work aims</a> – <a href="https://github.com/w3c/alreq/">GitHub repo</a> – <a href="#communication">Communication</a> – <a href="#join">How to join</a></span> </p>

--- a/misc/scripts/validate-html.sh
+++ b/misc/scripts/validate-html.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env sh
 
+# Ignore lang attribute for now because it doesn't understand `-t-` extensions.
+# TODO: Remove this after the fix in html5validator is published.
 html5validator index.html --ignore 'for attribute "lang" on element "td"'
+
 html5validator gap-analysis/index.html
 html5validator guidelines/index.html
 html5validator homepage/index.html

--- a/misc/scripts/validate-html.sh
+++ b/misc/scripts/validate-html.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+html5validator index.html --ignore 'for attribute "lang" on element "td"'
+html5validator gap-analysis/index.html
+html5validator guidelines/index.html
+html5validator homepage/index.html
+html5validator charter/index.html


### PR DESCRIPTION
Using <https://github.com/svenkreiss/html5validator> for HTML validation, which allows fast validation with the option to ignore specific errors.

Also fixed some errors in the homepage and charter HTMLs, to get the validation pass.

Fixes GH-170.