### PR TITLE
Fix grammar typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -615,7 +615,7 @@
 
 
           <p>Similarly, as noted in Joining Rule 4, sometimes an Arabic letter needs to take a
-          joining form when it would not happen normally. For example, some abbreviation methods us
+          joining form when it would not happen normally. For example, some abbreviation methods use
           Initial Form of letters, when possible, for every letter in the abbreviation. Again, in
           Unicode, a special character should be used to enforce joining on this letter. This
           character is called <span class="uname">U+200D ZERO WIDTH JOINER</span>, or


### PR DESCRIPTION
"...methods us Initial Form of letters..."  ==> "...methods use Initial Form of letters..." 

I think 'us' should be 'use'.