### PR TITLE
Shift and resize cropped tatweel illustration

### DIFF
--- a/images/tatweel.svg
+++ b/images/tatweel.svg
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="690px" height="323px" viewBox="0 0 690 323" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="790px" height="423px" viewBox="0 0 790 423" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 3.7.2 (28276) - http://www.bohemiancoding.com/sketch -->
     <title>Tatweel</title>
     <desc>Created with Sketch.</desc>
-    <defs></defs>
+    <defs/>
     <g id="Tatweel" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Group-Copy" transform="translate(-8.000000, 123.000000)">
+        <g id="Group-Copy" transform="translate(10.000000, 180.000000)">
             <text id="U+0645" font-family="SourceSansPro-Light, Source Sans Pro" font-size="32" font-weight="300" fill="#000000">
                 <tspan x="262" y="199">U+0645</tspan>
             </text>
@@ -37,7 +37,7 @@
                 <tspan x="184" y="135">←</tspan>
             </text>
         </g>
-        <g id="Group" transform="translate(222.000000, -77.000000)">
+        <g id="Group" transform="translate(232.000000, -20.000000)">
             <text id="U+0645" font-family="SourceSansPro-Light, Source Sans Pro" font-size="32" font-weight="300" fill="#000000">
                 <tspan x="202" y="199">U+0645</tspan>
             </text>


### PR DESCRIPTION
This changes the width, height and viewBox of the SVG and shifts elements a bit for the tatweel.svg in https://w3c.github.io/alreq/#h_justification_tatweel

Before:
![capture d ecran 2019-02-04 a 15 30 20](https://user-images.githubusercontent.com/1923747/52218296-40434f00-2892-11e9-8d99-3c21e0b53527.png)

After:
![capture d ecran 2019-02-04 a 15 33 15](https://user-images.githubusercontent.com/1923747/52218297-40dbe580-2892-11e9-8611-30b74be3e41e.png)
