### PR TITLE
Writing styles: continued the revision of writing style descriptions,…

### DIFF
--- a/index.html
+++ b/index.html
@@ -858,24 +858,36 @@
           <dd class="flexContainer">
             <figure class="floatedFigure">
               <img style="width: 200px; height: 147px;" src="images/kufiExampleQuran.jpg" alt=
-              "Kufi script">
+              "Kūfī ‘Abbassīd style">
 
               <figcaption>
-                Kūfī example [<a href=
+                Kūfī ‘Abbassīd style example [<a href=
                 "https://commons.wikimedia.org/wiki/File:A_section_of_the_Koran_-_Google_Art_Project.jpg">Source</a>].
               </figcaption>
             </figure>
 
 
-            <p>One of the oldest and best known Arabic scripts. It is characterized by its
-            decorative and pronounced geometric forms, well adapted for architectural designs. The
-            style grew with the beginning of Islam to satisfy a need for Muslims to codify the
-            Korʼan.</p>
+            <p>Kūfī is best understood as an umbrella term containing numerous variants, including widely diverging styles such as ornamental Kūfī, square Kūfī, and the so-called Eastern Kūfī, making the term highly ambiguous. The earliest forms of Kūfī are attested from the 7th century CE, making it one of the oldest Arabic writing styles. The Kūfī style that gained prominence in the production of Qur’ān manuscripts from the 7th century CE, also known as ‘Abbassīd style, is characterized by angular forms, with pronounced emphasis of horizontal strokes, very small or closed counter shapes, and uniformity of spacing.</p>
           </dd>
 
+          <dt>Maghribi (مغربي)</dt>
+
+          <dd class="flexContainer">
+            <figure class="floatedFigure">
+              <img style="width: 170px; height: 177px;" src="images/maghribi2.jpg" alt=
+              "Maghribi script">
+
+              <figcaption>
+                Maghribi example [<a href=
+                "https://commons.wikimedia.org/wiki/File:Maghribi_script_sura_5.jpg">Source</a>].
+              </figcaption>
+            </figure>
+
+            <p>The Maghribi (western) style probably evolved from the ‘Abbassīd style when Islamic conquests advanced through North Africa and into the Iberian peninsula in the 8th century CE. It maintained some structural characteristics from the ‘Abbassīd style and evolved further into a distinct regional hand. Used for writing the Korʼan as well as other scientific, legal and religious
+            manuscripts. <em>Rabat</em>, a <em><a href="#def_mabsut">mabsut</a></em> version of it, is widely used in some official printings in Morocco.</p>
+          </dd>
 
           <dt>Thuluth (ثلث)</dt>
-
 
           <dd class="flexContainer">
             <figure class="floatedFigure">
@@ -905,7 +917,7 @@
               "Naskh script">
 
               <figcaption>
-                Nask example [<a href=
+                Naskh example [<a href=
                 "https://commons.wikimedia.org/wiki/File:FirstSurahKoran_%28fragment%29.jpg">Source</a>].
               </figcaption>
             </figure>
@@ -915,6 +927,65 @@
             facilitate reading and pronunciation. Can be written at small sizes (traditionally
             using pens made of reeds and ink), which suits the production of longer texts used for
             boards and books intended for the general population, especially the Korʼan.</p>
+          </dd>
+
+          <dt>Taʻlīq (تعليق)</dt>
+
+
+          <dd class="flexContainer">
+            <figure class="floatedFigure">
+              <img style="width: 130px; height: 200px;" src="images/taliq.jpg" alt="Taʻlīq script">
+
+              <figcaption>
+                Taʻlīq example [<a href=
+                "https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Ta'liq_script_1.jpg/389px-Ta'liq_script_1.jpg">Source</a>].
+              </figcaption>
+            </figure>
+
+
+            <p><em>Taʻlīq</em> (hanging) is a beautiful script characterized by the precision and
+            stretch of its letters, its clarity, and its lack of complexity. Designed for Persian
+            language, until replaced by <em>Nastaʻlīq</em>.</p>
+          </dd>
+
+          <dt>Nastaʻlīq (نستعلیق)</dt>
+
+          <dd class="flexContainer">
+            <figure class="floatedFigure">
+              <img style="width: 130px; height: 130px;" src="images/nastaliq.jpg" alt=
+              "Nastaliq script">
+
+              <figcaption>
+                Nastaʻlīq example [<a href=
+                "https://commons.wikimedia.org/wiki/File:Khatt-e_Nastaliq.jpg">Source</a>].
+              </figcaption>
+            </figure>
+
+
+            <p>Persian version of <em>Taʻlīq</em>, derived from <em>Naskh</em> and <em>Taʻlīq</em>
+            and developed in the 8th and 9th centuries. It is like a <em>Taʻlīq</em> but easier to
+            write and read. <em>Shekasteh Nastaʻlīq</em> (literally means "broken Nastaʻlīq") is
+            also another derivation of those two, developed in the 15th century.</p>
+          </dd>
+
+          <dt>Dīwānī (ديواني)</dt>
+
+
+          <dd class="flexContainer">
+            <figure class="floatedFigure">
+              <img style="width: 250px; height: 101px;" src="images/diwani.png" alt=
+              "Diwani script">
+
+              <figcaption>
+                Dīwānī example [<a href=
+                "https://commons.wikimedia.org/wiki/File:Izzet_44.png">Source</a>].
+              </figcaption>
+            </figure>
+
+
+            <p>Used by the Ottoman court (<em>Diwan</em>) to write official documents. Some
+            variations of it are still in use today (e.g. hand written documents by some religious
+            officials).</p>
           </dd>
 
 
@@ -939,88 +1010,6 @@
             from it.</p>
           </dd>
 
-
-          <dt>Taʻlīq (تعليق)</dt>
-
-
-          <dd class="flexContainer">
-            <figure class="floatedFigure">
-              <img style="width: 130px; height: 200px;" src="images/taliq.jpg" alt="Taʻlīq script">
-
-              <figcaption>
-                Taʻlīq example [<a href=
-                "https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Ta'liq_script_1.jpg/389px-Ta'liq_script_1.jpg">Source</a>].
-              </figcaption>
-            </figure>
-
-
-            <p><em>Taʻlīq</em> (hanging) is a beautiful script characterized by the precision and
-            stretch of its letters, its clarity, and its lack of complexity. Designed for Persian
-            language, until replaced by <em>Nastaʻlīq</em>.</p>
-          </dd>
-
-
-          <dt>Dīwānī (ديواني)</dt>
-
-
-          <dd class="flexContainer">
-            <figure class="floatedFigure">
-              <img style="width: 250px; height: 101px;" src="images/diwani.png" alt=
-              "Diwani script">
-
-              <figcaption>
-                Dīwānī example [<a href=
-                "https://commons.wikimedia.org/wiki/File:Izzet_44.png">Source</a>].
-              </figcaption>
-            </figure>
-
-
-            <p>Used by the Ottoman court (<em>Diwan</em>) to write official documents. Some
-            variations of it are still in use today (e.g. hand written documents by some religious
-            officials).</p>
-          </dd>
-
-          <dt>Nastaʻlīq (نستعلیق)</dt>
-
-          <dd class="flexContainer">
-            <figure class="floatedFigure">
-              <img style="width: 130px; height: 130px;" src="images/nastaliq.jpg" alt=
-              "Nastaliq script">
-
-              <figcaption>
-                Nastaʻlīq example [<a href=
-                "https://commons.wikimedia.org/wiki/File:Khatt-e_Nastaliq.jpg">Source</a>].
-              </figcaption>
-            </figure>
-
-
-            <p>Persian version of <em>Taʻlīq</em>, derived from <em>Naskh</em> and <em>Taʻlīq</em>
-            and developed in the 8th and 9th centuries. It is like a <em>Taʻlīq</em> but easier to
-            write and read. <em>Shekasteh Nastaʻlīq</em> (literally means "broken Nastaʻlīq") is
-            also another derivation of those two, developed in the 15th century.</p>
-          </dd>
-
-
-          <dt>Maghribi (مغربي)</dt>
-
-
-          <dd class="flexContainer">
-            <figure class="floatedFigure">
-              <img style="width: 170px; height: 177px;" src="images/maghribi2.jpg" alt=
-              "Maghribi script">
-
-              <figcaption>
-                Maghribi example [<a href=
-                "https://commons.wikimedia.org/wiki/File:Maghribi_script_sura_5.jpg">Source</a>].
-              </figcaption>
-            </figure>
-
-
-            <p>Used in the past in the western Islamic world (Andalusia), and still now in North
-            Africa. Used for writing the Korʼan as well as other scientific, legal and religious
-            manuscripts. <em>Rabat</em>, a <em><a href="#def_mabsut">mabsut</a></em> version of it,
-            is widely used in some official printings in Morocco.</p>
-          </dd>
         </dl>
       </section>
     </section>


### PR DESCRIPTION
… replaced 'script' as a descriptor with 'style', re-phrased some items and added more details; began to organise the shown samples in a more meaningful, loosely historical order. This could (should?) be continued and maybe extended, the current selection appears somewhat arbitrary. For example the Six Pens could be added, and the sub-Saharan styles would also merit inclusion below the Maghribi.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TitusNemeth/alreq/pull/212.html" title="Last updated on Jan 28, 2020, 9:33 PM UTC (fbbf6bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/alreq/212/307c879...TitusNemeth:fbbf6bd.html" title="Last updated on Jan 28, 2020, 9:33 PM UTC (fbbf6bd)">Diff</a>