### PR TITLE
Use the respec-w3c profile

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
 
   <title>Text Layout Requirements for the Arabic Script</title>
-  <script src="https://www.w3.org/Tools/respec/respec-w3c-common" async class="remove"></script>
+  <script src="https://www.w3.org/Tools/respec/respec-w3c" async class="remove"></script>
   <script class="remove">
     var respecConfig = {
       // specification status (e.g. WD, LCWD, WG-NOTE, etc.). If in doubt use ED.


### PR DESCRIPTION
The w3c-common profile was no longer updated.
See https://github.com/w3c/respec/pull/2838 for details.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/alreq/pull/234.html" title="Last updated on Aug 22, 2020, 6:43 AM UTC (767f3e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/alreq/234/67d7543...767f3e2.html" title="Last updated on Aug 22, 2020, 6:43 AM UTC (767f3e2)">Diff</a>