### PR TITLE
Use the `group` configuration option

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,19 +34,10 @@
       ],
 
 
-      wg:           "Internationalization Working Group",
-      wgURI:        "https://www.w3.org/International/core/",
+      group:        "i18n",
       //wgPublicList: "public-i18n-arabic",
 
 	  github: "w3c/alreq",
-
-      // URI of the patent status for this WG, for Rec-track documents
-      // !!!! IMPORTANT !!!!
-      // This is important for Rec-track documents, do not copy a patent URI from a random
-      // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
-      // Team Contact.
-      wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/32113/status",
-      // !!!! IMPORTANT !!!! MAKE THE ABOVE BLINK IN YOUR HEAD
 
       localBiblio: {
 


### PR DESCRIPTION
The wg, wgId, wgURI, and wgPatentURI options are deprecated in favour of
“group”.

See https://lists.w3.org/Archives/Public/spec-prod/2020JulSep/0002.html


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/alreq/pull/235.html" title="Last updated on Aug 22, 2020, 6:44 AM UTC (c75f572)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/alreq/235/67d7543...c75f572.html" title="Last updated on Aug 22, 2020, 6:44 AM UTC (c75f572)">Diff</a>