### PR TITLE
Fix references

### DIFF
--- a/index.html
+++ b/index.html
@@ -600,7 +600,7 @@ character.</p>
 
 <p>The <dfn data-lt="bidirectional algorithm|bidi algorithm"><a href=
 "http://www.unicode.org/reports/tr9/">Unicode Bidirectional Algorithm</a></dfn> (or
-<span class="qterm">bidi algorithm</span>, for short) [[!UAX9]] details an algorithm for rendering right-to-left text and covers a myriad of situations, mixing different kinds of characters. A simpler explanation of the basics of the algorithm exists in the W3C article <a href="https://www.w3.org/International/articles/inline-bidi-markup/uba-basics">Unicode Bidirectional Algorithm basics</a>. [[UBA-BASICS]] You can refer to these documents for more information about Unicode’s bidirectional algorithm.</p>
+<span class="qterm">bidi algorithm</span>, for short) [[UAX9]] details an algorithm for rendering right-to-left text and covers a myriad of situations, mixing different kinds of characters. A simpler explanation of the basics of the algorithm exists in the W3C article <a href="https://www.w3.org/International/articles/inline-bidi-markup/uba-basics">Unicode Bidirectional Algorithm basics</a>. [[UBA-BASICS]] You can refer to these documents for more information about Unicode’s bidirectional algorithm.</p>
 
 <p>A brief overview of the <a>bidirectional algorithm</a> follows, because the direction is an essential part of how Arabic script is used.</p>
 
@@ -648,7 +648,7 @@ direction of these characters is derived from their surrounding characters. If a
 essentials of how Arabic text is transformed for rendering. The actual algorithm deals with many more character types and edge cases. Please refer to <a href=
 "https://www.w3.org/International/articles/inline-bidi-markup/uba-basics">Unicode
 Bidirectional Algorithm basics</a> [[UBA-BASICS]] for more information or <a href=
-"http://www.unicode.org/reports/tr9/">Unicode Bidirectional Algorithm</a> [[!UAX9]] for the official detailed documentation.</p>
+"http://www.unicode.org/reports/tr9/">Unicode Bidirectional Algorithm</a> [[UAX9]] for the official detailed documentation.</p>
 </section>
 
 
@@ -1070,8 +1070,8 @@ scripts) are non-joining and do not take any joining forms other than Isolated.<
 
 <p>For more the details on <span class="qterm">Arabic Cursive Joining algorithm</span>,
 please refer to chapter <a href=
-"http://www.unicode.org/versions/Unicode9.0.0/ch09.pdf">Middle East-I — Modern and
-Liturgical Scripts</a> of The Unicode Standard. [[!UNICODE]]</p>
+"http://www.unicode.org/versions/Unicode15.0.0/ch09.pdf">Middle East-I — Modern and
+Liturgical Scripts</a> of The Unicode Standard. [[UNICODE]]</p>
 </section>
 
 
@@ -1189,10 +1189,10 @@ dates back to 1514, lacks word-space boundaries and shows all characteristics of
 <li>the misuse of space in place of ZWNJ in some Arabic script languages.</li>
 </ul>
 
-<p>Unicode Text Segmentation [[!UAX29]] describes guidelines for determining most significant text boundaries independent of language and orthographic conventions. These guidelines shape a logical set of rules for default boundary determination based on Unicode Standard uniform character model.</p>
+<p>Unicode Text Segmentation [[UAX29]] describes guidelines for determining most significant text boundaries independent of language and orthographic conventions. These guidelines shape a logical set of rules for default boundary determination based on Unicode Standard uniform character model.</p>
 
 <p>Beyond this default boundary determination model, the locale-specific boundary specifications, including cases which require boundary suppression, are available in
-[[!CLDR]].</p>
+[[CLDR]].</p>
 
 <p>For line segmentation (or more precisely, where line breaks are allowed) see section 4.1 and for details paragraph boundaries see Section 4.3.</p>
 </section>


### PR DESCRIPTION
Remove '!' from the start of the reference to fix a few ReSpec warnings, i.e., "Normative references in informative sections are not allowed".

I also updated the Unicode version from 9 to 15.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/alreq/pull/258.html" title="Last updated on Oct 23, 2022, 3:06 AM UTC (c60dbb8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/alreq/258/461bf19...c60dbb8.html" title="Last updated on Oct 23, 2022, 3:06 AM UTC (c60dbb8)">Diff</a>