### PR TITLE
Link to dual-joining and right-joining letters

### DIFF
--- a/index.html
+++ b/index.html
@@ -1030,13 +1030,13 @@ alt="A word that is just one long multi-letter closed segment." style="width:60%
 <p>There are three possible types of these segments:</p>
 
 <ul>
-<li><dfn>Open-On-Left Segment</dfn>, which contains one or more Dual-Joining letters,
+<li><dfn>Open-On-Left Segment</dfn>, which contains one or more <a>Dual-Joining</a> letters,
 starting with an Initial form and continuing with zero or more Medial forms.</li>
 
 <li><dfn>Open-On-Right Segment</dfn>, which starts with zero or more Medial Form
 letters, and ends with a Final Form letter.</li>
 
-<li><dfn>Open-On-Both-Sides Segment</dfn>, which contains one or more Dual-Joining
+<li><dfn>Open-On-Both-Sides Segment</dfn>, which contains one or more <a>Dual-Joining</a>
 letters, all in their Medial Form.</li>
 </ul>
 
@@ -1092,7 +1092,7 @@ Liturgical Scripts</a> of The Unicode Standard. [[UNICODE]]</p>
 <h5>Joining and Intra-Word Spaces</h5>
 
 <p>The only spaces inside Arabic words are created near characters that are not
-dual-joining. When adjusting intra-word spaces (i.e. the space inside the words) only these spaces can be adjusted. Moving two joined characters closer to or further from each other creates undesirable results.</p>
+<a>dual-joining</a>. When adjusting intra-word spaces (i.e. the space inside the words) only these spaces can be adjusted. Moving two joined characters closer to or further from each other creates undesirable results.</p>
 </section>
 
 
@@ -1103,7 +1103,7 @@ dual-joining. When adjusting intra-word spaces (i.e. the space inside the words)
 <section id="h_joining_and_transparency">
 <h5>Transparency</h5>
 
-<p>Arabic fonts achieve joining by overlapping letters. A left-joining letter extends out of its bounding box from the left side and a right-joining letter extends out of its bounding box from the right side. Making each letter transparent can expose these
+<p>Arabic fonts achieve joining by overlapping letters. A left-joining letter extends out of its bounding box from the left side and a <a>right-joining</a> letter extends out of its bounding box from the right side. Making each letter transparent can expose these
 overlapping joinings, which should be avoided. Joining the paths of the joined letter into a single shape can remove the overlappings and create the good results.</p>
 
 <figure id="fig_joining-and-transparency">
@@ -1684,7 +1684,7 @@ result, the software would fall back to inter-word spacing and stretch the space
 <section id="h_justification_tatweel">
 <h4>Tatweel</h4>
 
-<p>Tatweel is a dual-joining character that can be inserted between two joined letters to widen their connection. In The Unicode Standard, tatweel is represented as <span class="codepoint" translate="no"><span lang="ar" dir="rtl">&#x0640;</span> [<span class="uname">U+0640 ARABIC TATWEEL</span>]</span>.</p>
+<p>Tatweel is a <a>dual-joining</a> character that can be inserted between two joined letters to widen their connection. In The Unicode Standard, tatweel is represented as <span class="codepoint" translate="no"><span lang="ar" dir="rtl">&#x0640;</span> [<span class="uname">U+0640 ARABIC TATWEEL</span>]</span>.</p>
 
 <figure>
 <img src="images/tatweel.svg" alt="Tatweel" style="width:60%;">


### PR DESCRIPTION
The definition is in https://www.w3.org/TR/alreq/#h_joining_categories


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/alreq/pull/262.html" title="Last updated on Mar 21, 2023, 4:15 AM UTC (129a455)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/alreq/262/4c22970...129a455.html" title="Last updated on Mar 21, 2023, 4:15 AM UTC (129a455)">Diff</a>